### PR TITLE
Update streamable HTTP protocol metadata to 2025-07-09

### DIFF
--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -271,7 +271,7 @@ const server = createServer(async (req, res) => {
         old_endpoint: "/sse",
         new_endpoint: "/mcp",
         transport: "MCP Streamable HTTP",
-        protocol_version: "2025-06-18"
+        protocol_version: "2025-07-09"
       },
       documentation: "https://github.com/marianfoo/mcp-sap-docs#connect-from-your-mcp-client",
       alternatives: {

--- a/src/streamable-http-server.ts
+++ b/src/streamable-http-server.ts
@@ -105,7 +105,7 @@ async function main() {
         old_endpoint: "/sse",
         new_endpoint: "/mcp",
         transport: "MCP Streamable HTTP", 
-        protocol_version: "2025-06-18"
+        protocol_version: "2025-07-09"
       },
       documentation: "https://github.com/marianfoo/mcp-sap-docs#connect-from-your-mcp-client",
       alternatives: {
@@ -147,11 +147,25 @@ async function main() {
           eventStore, // Enable resumability
           onsessioninitialized: (sessionId: string) => {
             // Store the transport by session ID when session is initialized
-            logger.logTransportEvent('session_initialized', sessionId, { 
+            logger.logTransportEvent('session_initialized', sessionId, {
               requestId,
               transportCount: Object.keys(transports).length + 1
             });
             transports[sessionId] = transport;
+          },
+          onsessionclosed: (sessionId: string) => {
+            if (transports[sessionId]) {
+              delete transports[sessionId];
+              logger.logTransportEvent('session_closed', sessionId, {
+                trigger: 'onsessionclosed',
+                transportCount: Object.keys(transports).length
+              });
+            } else {
+              logger.logTransportEvent('session_closed', sessionId, {
+                trigger: 'onsessionclosed',
+                note: 'session already cleaned up'
+              });
+            }
           }
         });
         
@@ -230,7 +244,7 @@ async function main() {
       version: VERSION,
       timestamp: new Date().toISOString(),
       transport: 'streamable-http',
-      protocol: '2025-06-18'
+      protocol: '2025-07-09'
     });
   });
 
@@ -251,7 +265,7 @@ async function main() {
   console.log(`
 ==============================================
 MCP STREAMABLE HTTP SERVER
-Protocol version: 2025-06-18
+Protocol version: 2025-07-09
 
 Endpoint: /mcp
 Methods: GET, POST, DELETE


### PR DESCRIPTION
## Summary
- replace legacy protocol banner and redirect metadata with the 2025-07-09 schema tag in both HTTP server entry points
- hook into the new `onsessionclosed` lifecycle to remove transports immediately when a DELETE /mcp arrives

## Testing
- npm run build:tsc
- Manually exercised POST/GET/DELETE /mcp against the streamable server

------
https://chatgpt.com/codex/tasks/task_e_68e51d51d77083289a75c1d36900b5a2