### PR TITLE
chore: adopt MCP 2025-07-09 schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "esm": true
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.18.0",
+    "@modelcontextprotocol/sdk": "^1.19.0",
     "better-sqlite3": "^12.2.0",
     "cors": "^2.8.5",
     "express": "^4.21.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "esm": true
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.17.2",
+    "@modelcontextprotocol/sdk": "^1.18.0",
     "better-sqlite3": "^12.2.0",
     "cors": "^2.8.5",
     "express": "^4.21.2",

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/marianfoo/mcp-sap-docs",
     "source": "github"
   },
-  "version": "0.3.9",
+  "version": "0.3.15",
   "packages": [
     {
       "registry_type": "npm",
       "registry_base_url": "https://registry.npmjs.org",
       "identifier": "mcp-sap-docs",
-      "version": "0.3.9",
+      "version": "0.3.15",
       "transport": {
         "type": "stdio"
       }

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,18 +4,23 @@ import { logger } from "./lib/logger.js";
 import { BaseServerHandler } from "./lib/BaseServerHandler.js";
 
 function createServer() {
+  const serverOptions: NonNullable<ConstructorParameters<typeof Server>[1]> & {
+    protocolVersions?: string[];
+  } = {
+    protocolVersions: ["2025-07-09"],
+    capabilities: {
+      // resources: {},  // DISABLED: Causes 60,000+ resources which breaks Cursor
+      tools: {},      // Enable tools capability
+      prompts: {}     // Enable prompts capability for 2025-07-09 protocol
+    }
+  };
+
   const srv = new Server({
     name: "Local SAP Docs",
     description:
       "Offline SAPUI5 & CAP documentation server with SAP Community, SAP Help Portal, and ABAP Keyword Documentation integration",
     version: "0.1.0"
-  }, {
-    capabilities: { 
-      // resources: {},  // DISABLED: Causes 60,000+ resources which breaks Cursor
-      tools: {},      // Enable tools capability
-      prompts: {}     // Enable prompts capability for 2025-06-18 protocol
-    }
-  });
+  }, serverOptions);
 
   // Configure server with shared handlers
   BaseServerHandler.configureServer(srv);

--- a/src/streamable-http-server.ts
+++ b/src/streamable-http-server.ts
@@ -56,17 +56,22 @@ class InMemoryEventStore {
 }
 
 function createServer() {
+  const serverOptions: NonNullable<ConstructorParameters<typeof Server>[1]> & {
+    protocolVersions?: string[];
+  } = {
+    protocolVersions: ["2025-07-09"],
+    capabilities: {
+      // resources: {},  // DISABLED: Causes 60,000+ resources which breaks Cursor
+      tools: {}       // Enable tools capability
+    }
+  };
+
   const srv = new Server({
     name: "SAP Docs Streamable HTTP",
     description:
       "SAP documentation server with Streamable HTTP transport - supports SAPUI5, CAP, wdi5, SAP Community, SAP Help Portal, and ABAP Keyword Documentation integration",
     version: VERSION
-  }, {
-    capabilities: { 
-      // resources: {},  // DISABLED: Causes 60,000+ resources which breaks Cursor
-      tools: {}       // Enable tools capability 
-    }
-  });
+  }, serverOptions);
 
   // Configure server with shared handlers
   BaseServerHandler.configureServer(srv);


### PR DESCRIPTION
## Summary
- bump @modelcontextprotocol/sdk to the release that supports the 2025-07-09 protocol schema
- advertise 2025-07-09 protocol support from both stdio and streamable HTTP servers
- align server metadata versions with the published package version

## Testing
- npm run build
- VITEST_REPORTER=basic npm run test:url-generation


------
https://chatgpt.com/codex/tasks/task_e_68e51d4749dc832886b2dba8da611b13