### PR TITLE
Update README.md for Eclipse

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Eclipse users can integrate the SAP Docs MCP server with GitHub Copilot for seam
    - Open the Copilot chat by pressing <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>I</kbd>
    - In the chat area click on the "Configure Tools..." icon
 
-4. **Add SAP Docs MCP Server**
+3. **Add SAP Docs MCP Server**
    Add the following to the "Server Configurations" and click on "Apply"
    ```json
    {
@@ -216,7 +216,7 @@ Eclipse users can integrate the SAP Docs MCP server with GitHub Copilot for seam
    }
    ```
 
-6. **Verify Configuration**
+4. **Verify Configuration**
    - After clicking "Apply" the server should appear in your MCP servers list
    - Status should show as "Connected" when active
 


### PR DESCRIPTION
Update the instructions to setup the MCP server in Eclipse.

While following your instructions I noticed that some things were named differently in the latest Copilot version (0.12.x).

Also there is a shortcut to open the MCP settings by directly launching them from the chat area. So I simplified the instructions in your guide. Also the JSON did not work so I updated it to match the format proposed by Copilot.

Source: https://docs.github.com/de/copilot/how-tos/provide-context/use-mcp/extend-copilot-chat-with-mcp?tool=eclipse