### PR TITLE
fix: stabilize citation URL generation

### DIFF
--- a/config/variants/abap.metadata.json
+++ b/config/variants/abap.metadata.json
@@ -130,9 +130,9 @@
       "description": "SAP Business Technology Platform documentation",
       "libraryId": "/btp-cloud-platform",
       "sourcePath": "btp-cloud-platform/docs",
-      "baseUrl": "https://github.com/SAP-docs/btp-cloud-platform/blob/main",
-      "pathPattern": "/docs/{file}",
-      "anchorStyle": "github"
+      "baseUrl": "https://help.sap.com/docs/BTP/65de2977205c403bbc107264b8eccf4b",
+      "pathPattern": "/{file}.html",
+      "anchorStyle": "sap-help"
     },
     {
       "id": "sap-artificial-intelligence",
@@ -143,9 +143,9 @@
       "description": "SAP AI Core and SAP AI Launchpad documentation",
       "libraryId": "/sap-artificial-intelligence",
       "sourcePath": "sap-artificial-intelligence/docs",
-      "baseUrl": "https://github.com/SAP-docs/sap-artificial-intelligence/blob/main",
-      "pathPattern": "/docs/{file}",
-      "anchorStyle": "github"
+      "baseUrl": "https://help.sap.com/docs",
+      "pathPattern": "/{file}.html",
+      "anchorStyle": "sap-help"
     },
     {
       "id": "teched2025-dt260",

--- a/config/variants/sap-docs.json
+++ b/config/variants/sap-docs.json
@@ -29,6 +29,7 @@
     "/btp-cloud-platform",
     "/sap-artificial-intelligence",
     "/terraform-provider-btp",
+    "/teched2025-dt260",
     "/architecture-center"
   ],
   "submodulePaths": [
@@ -56,6 +57,7 @@
     "sources/sap-artificial-intelligence",
     "sources/abap-atc-cr-cv-s4hc",
     "sources/terraform-provider-btp",
+    "sources/teched2025-dt260",
     "sources/architecture-center"
   ],
   "tools": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "inspect": "npx @modelcontextprotocol/inspector",
     "test": "npm run test:url-generation && npm run test:integration",
     "test:sparse-checkout": "npx vitest run test/sparse-checkout.test.ts",
-    "test:url-generation": "npm run build:tsc && npx vitest run test/comprehensive-url-generation.test.ts test/prompts.test.ts test/software-heroes-afm.test.ts",
+    "test:url-generation": "npm run build:tsc && npx vitest run test/comprehensive-url-generation.test.ts test/source-url-matrix.test.ts test/search-response-schema.test.ts test/prompts.test.ts test/software-heroes-afm.test.ts",
     "test:url-generation:debug": "npm run build:tsc && DEBUG_TESTS=true npx vitest run test/comprehensive-url-generation.test.ts",
     "test:mcp-urls": "npm run build:tsc && npx vitest run test/mcp-search-url-verification.test.ts",
     "test:integration": "npm run build && node test/tools/run-tests.js",

--- a/scripts/build-index.ts
+++ b/scripts/build-index.ts
@@ -211,7 +211,7 @@ const SOURCES: SourceConfig[] = [
     id: "/cap-fiori-showcase",
     name: "CAP Fiori Elements Feature Showcase",
     description: "SAP Fiori Elements features and annotations showcase using CAP",
-    filePattern: "*.md",
+    filePattern: "**/*.{md,cds}",
     type: "markdown" as const
   },
   {
@@ -923,4 +923,4 @@ async function main() {
   console.log("✅  Index built with", Object.keys(all).length, "libraries.");
 }
 
-main(); 
+main();

--- a/src/lib/BaseServerHandler.ts
+++ b/src/lib/BaseServerHandler.ts
@@ -46,6 +46,8 @@ import { search } from "./search.js";
 import { CONFIG } from "./config.js";
 import { loadMetadata, getDocUrlConfig } from "./metadata.js";
 import { generateDocumentationUrl, formatSearchResult } from "./url-generation/index.js";
+import { extractLibraryIdFromPath } from "./url-generation/utils.js";
+import { extractSourceUrlFromText, readSourceContentSync } from "./sourceContent.js";
 import { isToolEnabled, getVariantName } from "./variant.js";
 import { searchDiscoveryCenter, getDiscoveryCenterServiceDetails } from "./discoveryCenter/index.js";
 
@@ -75,7 +77,7 @@ interface DocumentResult {
 /**
  * Create structured JSON response for search results (ChatGPT-compatible)
  */
-function createSearchResponse(results: SearchResult[]): any {
+function createSearchResponse(results: SearchResult[], extra: Record<string, any> = {}): any {
   // Clean the results to avoid JSON serialization issues in MCP protocol
   const cleanedResults = results.map(result => ({
     // ChatGPT requires: id, title, url (other fields optional)
@@ -90,16 +92,42 @@ function createSearchResponse(results: SearchResult[]): any {
     metadata: result.metadata
   }));
   
+  const payload = { results: cleanedResults, ...extra };
+
   // ChatGPT expects: { "results": [...] } in JSON-encoded text content
   return {
     content: [
       {
         type: "text",
-        text: JSON.stringify({ results: cleanedResults })
+        text: JSON.stringify(payload)
       }
     ],
-    structuredContent: { results: cleanedResults }
+    structuredContent: payload
   };
+}
+
+function createEmptySearchResponse(message: string, requestId?: string, extra: Record<string, any> = {}): any {
+  return createSearchResponse([], {
+    error: message,
+    requestId: requestId || 'unknown',
+    ...extra
+  });
+}
+
+function isAbsoluteHttpUrl(url?: string): boolean {
+  return !!url && /^https?:\/\//i.test(url);
+}
+
+function chooseSearchResultUrl(docUrl: string | null, path: string | undefined, id: string): string {
+  if (isAbsoluteHttpUrl(docUrl || undefined)) {
+    return docUrl!;
+  }
+
+  if (isAbsoluteHttpUrl(path)) {
+    return path!;
+  }
+
+  return `#${id}`;
 }
 
 /**
@@ -1017,7 +1045,7 @@ RETURNS (JSON):
           if (topResults.length === 0) {
             console.log(`⚠️ [SEARCH TOOL] No results found for query: "${query}"`);
             logger.logToolSuccess(name, timing.requestId, timing.startTime, 0, { fallback: false });
-            return createErrorResponse(
+            return createEmptySearchResponse(
               `No results for "${query}". Try ABAP keywords ("SELECT", "LOOP", "RAP"), add "cloud" for ABAP Cloud syntax, or be more specific.`,
               timing.requestId
             );
@@ -1031,13 +1059,14 @@ RETURNS (JSON):
             const topic = r.id.startsWith(libraryId) ? r.id.slice(libraryId.length + 1) : '';
             
             const config = getDocUrlConfig(libraryId);
-            const docUrl = config ? generateDocumentationUrl(libraryId, r.relFile || '', r.text, config) : null;
+            const sourceContent = config ? readSourceContentSync(libraryId, r.relFile || '') : null;
+            const docUrl = config ? generateDocumentationUrl(libraryId, r.relFile || '', sourceContent || r.text, config) : null;
             
             return {
               // ChatGPT-required format: id, title, url
               id: r.id,
               title: r.text.split('\n')[0] || r.id,
-              url: docUrl || r.path || `#${r.id}`,
+              url: chooseSearchResultUrl(docUrl, r.path, r.id),
               // Additional fields
               library_id: libraryId,
               topic: topic,
@@ -1074,7 +1103,7 @@ RETURNS (JSON):
             
             if (!res.results.length) {
               logger.logToolSuccess(name, timing.requestId, timing.startTime, 0, { fallback: true });
-              return createErrorResponse(
+              return createEmptySearchResponse(
                 res.error || `No fallback results for "${query}". Try ABAP keywords ("SELECT", "LOOP", "RAP"), add "cloud" for ABAP Cloud syntax, or be more specific.`,
                 timing.requestId
               );
@@ -1097,7 +1126,7 @@ RETURNS (JSON):
             return createSearchResponse(fallbackResults);
           } catch (fallbackError) {
             logger.logToolError(name, timing.requestId, timing.startTime, fallbackError, true);
-            return createErrorResponse(
+            return createEmptySearchResponse(
               `Search temporarily unavailable. Wait 30 seconds and retry, or use more specific search terms.`,
               timing.requestId
             );
@@ -1135,13 +1164,15 @@ RETURNS (JSON):
           }
           
           // Transform document content to ChatGPT-compatible format
-          const config = getDocUrlConfig(library_id);
-          const docUrl = config ? generateDocumentationUrl(library_id, '', text, config) : null;
+          const fetchedSourceUrl = extractSourceUrlFromText(text);
+          const rootLibraryId = library_id.startsWith('/') ? extractLibraryIdFromPath(library_id) : library_id;
+          const config = getDocUrlConfig(rootLibraryId);
+          const docUrl = config ? generateDocumentationUrl(rootLibraryId, '', text, config) : null;
           const document: DocumentResult = {
             id: library_id,
             title: library_id.replace(/^\//, '').replace(/\//g, ' > ') + (topic ? ` (${topic})` : ''),
             text: text,
-            url: docUrl || `#${library_id}`,
+            url: fetchedSourceUrl || docUrl || `#${library_id}`,
             metadata: {
               source: 'abap-docs',
               library: library_id,
@@ -1243,23 +1274,11 @@ RETURNS (JSON):
 
           if (!communityResponse.results.length) {
             logger.logToolSuccess(name, timing.requestId, timing.startTime, 0);
-            return {
-              content: [
-                {
-                  type: "text",
-                  text: JSON.stringify({
-                    error: communityResponse.error || `No SAP Community posts found for "${query}". Try different keywords.`,
-                    requestId: timing.requestId,
-                    requestUrl,
-                  }),
-                },
-              ],
-              structuredContent: {
-                error: communityResponse.error || `No SAP Community posts found for "${query}". Try different keywords.`,
-                requestId: timing.requestId,
-                requestUrl,
-              },
-            };
+            return createEmptySearchResponse(
+              communityResponse.error || `No SAP Community posts found for "${query}". Try different keywords.`,
+              timing.requestId,
+              { requestUrl }
+            );
           }
 
           const searchResults: SearchResult[] = communityResponse.results.map((r, index) => ({
@@ -1286,23 +1305,11 @@ RETURNS (JSON):
           };
         } catch (error) {
           logger.logToolError(name, timing.requestId, timing.startTime, error);
-          return {
-            content: [
-              {
-                type: "text",
-                text: JSON.stringify({
-                  error: "Error searching SAP Community. Please try again later.",
-                  requestId: timing.requestId,
-                  requestUrl,
-                }),
-              },
-            ],
-            structuredContent: {
-              error: "Error searching SAP Community. Please try again later.",
-              requestId: timing.requestId,
-              requestUrl,
-            },
-          };
+          return createEmptySearchResponse(
+            "Error searching SAP Community. Please try again later.",
+            timing.requestId,
+            { requestUrl }
+          );
         }
       }
 

--- a/src/lib/communityBestMatch.ts
+++ b/src/lib/communityBestMatch.ts
@@ -23,7 +23,8 @@ type Options = {
   userAgent?: string;     // optional UA override
 };
 
-const LIQL_BASE = "https://community.sap.com/api/2.0/search";
+const COMMUNITY_BASE = "https://community.sap.com";
+const LIQL_BASE = `${COMMUNITY_BASE}/api/2.0/search`;
 
 const stripTags = (html = "") =>
   html
@@ -37,12 +38,29 @@ const stripTags = (html = "") =>
     .trim();
 
 // Extract post ID from view_href URL
-const extractPostId = (url: string): string | undefined => {
+export const extractPostId = (url: string): string | undefined => {
   const urlMatch = url.match(/\/(?:ba-p|td-p|qaq-p|qaa-p|m-p)\/(\d+)/);
   if (urlMatch) return urlMatch[1];
   const endMatch = url.match(/\/(\d+)(?:[#?]|$)/);
   return endMatch ? endMatch[1] : undefined;
 };
+
+export function normalizeCommunityUrl(url?: string, postId?: string): string {
+  if (url) {
+    if (/^https?:\/\//i.test(url)) {
+      return url;
+    }
+
+    const normalizedPath = url.startsWith('/') ? url : `/${url}`;
+    return `${COMMUNITY_BASE}${normalizedPath}`;
+  }
+
+  if (postId) {
+    return `${COMMUNITY_BASE}/t5/forums/messagepage/message-id/${encodeURIComponent(postId)}`;
+  }
+
+  return COMMUNITY_BASE;
+}
 
 /**
  * Build a LiQL URL for full-text search on SAP Community.
@@ -88,8 +106,9 @@ async function executeLiqlSearch(url: string, userAgent?: string): Promise<any[]
 
 function mapItemsToHits(items: any[]): BestMatchHit[] {
   return items.map((item: any): BestMatchHit => {
-    const viewHref = item.view_href || "";
-    const postId = String(item.id || "") || extractPostId(viewHref);
+    const rawViewHref = item.view_href || "";
+    const postId = String(item.id || "") || extractPostId(rawViewHref);
+    const viewHref = normalizeCommunityUrl(rawViewHref, postId);
     const snippet = item.search_snippet ? stripTags(item.search_snippet).slice(0, CONFIG.EXCERPT_LENGTH_COMMUNITY) : undefined;
     const published = item.post_time
       ? new Date(item.post_time).toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" })
@@ -239,7 +258,7 @@ export async function getCommunityPostsByIds(postIds: string[], userAgent?: stri
     // Process each post
     for (const post of data.data.items) {
       const postDate = post.post_time ? new Date(post.post_time).toLocaleDateString() : 'Unknown';
-      const postUrl = post.view_href || `https://community.sap.com/t5/technology-blogs-by-sap/bg-p/t/${post.id}`;
+      const postUrl = normalizeCommunityUrl(post.view_href, String(post.id || ""));
       
       const fullContent = `# ${post.subject}
 

--- a/src/lib/localDocs.ts
+++ b/src/lib/localDocs.ts
@@ -19,6 +19,7 @@ import {
 } from "./metadata.js";
 import { generateDocumentationUrl as generateUrl } from "./url-generation/index.js";
 import { getSapHelpContent } from "./sapHelp.js";
+import { readSourceContentSync } from "./sourceContent.js";
 
 // Use the new URL generation system
 function generateDocumentationUrl(libraryId: string, relFile: string, content: string): string | null {
@@ -28,6 +29,23 @@ function generateDocumentationUrl(libraryId: string, relFile: string, content: s
   }
 
   return generateUrl(libraryId, relFile, content, config);
+}
+
+function getSearchResultUrl(result: any): string | null {
+  if (result.url) {
+    return result.url;
+  }
+
+  const { libraryId } = parseDocumentId(result.docId);
+  const relFile = result.relFile || '';
+
+  if (!relFile) {
+    const config = getDocUrlConfig(libraryId);
+    return config?.baseUrl || null;
+  }
+
+  const sourceContent = readSourceContentSync(libraryId, relFile);
+  return generateDocumentationUrl(libraryId, relFile, sourceContent || result.docDescription || result.docTitle || '');
 }
 
 // Get the directory of this script and find the project root
@@ -138,10 +156,14 @@ function formatSearchResultEntry(result: any, queryContext: string): string {
   const score = result.score.toFixed(0);
   const description = result.docDescription.substring(0, 100);
   const contextEmoji = getContextEmoji(queryContext);
+  const resultUrl = getSearchResultUrl(result);
   
   let formatted = `${contextEmoji} **${result.docTitle}** (Score: ${score})\n`;
   formatted += `   📄 ${description}${description.length >= 100 ? '...' : ''}\n`;
   formatted += `   📂 Library: \`${libraryId}\`\n`;
+  if (resultUrl) {
+    formatted += `   🔗 ${resultUrl}\n`;
+  }
   
   if (topic) {
     formatted += `   🎯 Topic: \`${topic}\`\n`;
@@ -154,11 +176,16 @@ function formatSearchResultEntry(result: any, queryContext: string): string {
 }
 
 // Format JavaScript content for better readability in documentation context
-function formatJSDocContent(content: string, controlName: string): string {
+function formatJSDocContent(content: string, filePath: string, controlName: string): string {
   const lines = content.split('\n');
   const result: string[] = [];
+  const documentationUrl = generateDocumentationUrl('/openui5-api', filePath, content);
   
   result.push(`# ${controlName} - OpenUI5 Control API`);
+  result.push('');
+  result.push(`**Source:** OpenUI5 API Documentation`);
+  result.push(`**URL:** ${documentationUrl || 'Documentation URL not available'}`);
+  result.push(`**File:** ${filePath}`);
   result.push('');
   
   // Extract main JSDoc comment
@@ -249,10 +276,15 @@ function formatSampleContent(content: string, filePath: string, title: string): 
   const fileExt = path.extname(filePath);
   const controlName = title.split(' ')[0]; // Extract control name from title
   const fileName = path.basename(filePath);
+  const documentationUrl = generateDocumentationUrl('/openui5-samples', filePath, content);
   
   const result: string[] = [];
   
   result.push(`# ${title}`);
+  result.push('');
+  result.push(`**Source:** OpenUI5 Samples Documentation`);
+  result.push(`**URL:** ${documentationUrl || 'Documentation URL not available'}`);
+  result.push(`**File:** ${filePath}`);
   result.push('');
   
   // Add file information
@@ -1168,6 +1200,7 @@ export async function searchLibraries(query: string, fileContent?: string): Prom
             docId: doc.id,
             docTitle: doc.title,
             docDescription: doc.description,
+            relFile: doc.relFile,
             matchType,
             snippetCount: doc.snippetCount,
             source: 'docs',
@@ -1227,6 +1260,7 @@ export async function searchLibraries(query: string, fileContent?: string): Prom
             docId: doc.id,
             docTitle: doc.title,
             docDescription: doc.description,
+            relFile: doc.relFile,
             matchType: bestMatchType,
             snippetCount: doc.snippetCount,
             source: 'docs'
@@ -1367,12 +1401,13 @@ export async function searchLibraries(query: string, fileContent?: string): Prom
   return {
     results: topResults.map((r, index) => {
       const { libraryId, topic } = parseDocumentId(r.docId);
+      const resultUrl = getSearchResultUrl(r);
       return {
         library_id: libraryId,
         topic: topic,
         id: r.docId,
         title: r.docTitle,
-        url: r.url || `#${r.docId}`,
+        url: resultUrl || `#${r.docId}`,
         snippet: r.docDescription,
         score: r.score,
         metadata: {
@@ -1421,7 +1456,7 @@ export async function fetchLibraryDocumentation(
         
         // For JavaScript API files, format the content for better readability
         if (doc.relFile && doc.relFile.endsWith('.js') && lib.id === '/openui5-api') {
-          return formatJSDocContent(content, doc.title || '');
+          return formatJSDocContent(content, doc.relFile, doc.title || '');
         }
         // For sample files, format them appropriately
         else if (lib.id === '/openui5-samples') {
@@ -1469,7 +1504,7 @@ ${content}
           
           // For JavaScript API files, format the content for better readability
           if (doc.relFile && doc.relFile.endsWith('.js') && lib.id === '/openui5-api') {
-            return formatJSDocContent(content, doc.title || '');
+            return formatJSDocContent(content, doc.relFile, doc.title || '');
           }
           // For sample files, format them appropriately
           else if (lib.id === '/openui5-samples') {
@@ -1524,7 +1559,7 @@ ${content}
         
         // For JavaScript API files, format the content for better readability
         if (doc.relFile && doc.relFile.endsWith('.js') && baseLib.id === '/openui5-api') {
-          const formattedContent = formatJSDocContent(content, doc.title || '');
+          const formattedContent = formatJSDocContent(content, doc.relFile, doc.title || '');
           parts.push(formattedContent);
         }
         // For sample files, format them appropriately
@@ -1578,7 +1613,7 @@ ${content}
         
         // Format the content appropriately based on library type
         if (doc.relFile && doc.relFile.endsWith('.js') && lib.id === '/openui5-api') {
-          return formatJSDocContent(content, doc.title || '');
+          return formatJSDocContent(content, doc.relFile, doc.title || '');
         } else if (lib.id === '/openui5-samples') {
           return formatSampleContent(content, doc.relFile, doc.title || '');
         } else if (getDocUrlConfig(lib.id)) {
@@ -1623,7 +1658,7 @@ ${content}
         const content = await fs.readFile(abs, "utf8");
         
         if (doc.relFile && doc.relFile.endsWith('.js') && lib.id === '/openui5-api') {
-          const formattedContent = formatJSDocContent(content, doc.title || '');
+          const formattedContent = formatJSDocContent(content, doc.relFile, doc.title || '');
           parts.push(formattedContent);
         } else if (lib.id === '/openui5-samples') {
           const formattedContent = formatSampleContent(content, doc.relFile, doc.title || '');
@@ -1670,7 +1705,7 @@ ${content}
     
     // For JavaScript API files, format the content for better readability
     if (doc.relFile && doc.relFile.endsWith('.js') && lib.id === '/openui5-api') {
-      const formattedContent = formatJSDocContent(content, doc.title || '');
+      const formattedContent = formatJSDocContent(content, doc.relFile, doc.title || '');
       parts.push(formattedContent);
     }
     // For sample files, format them appropriately
@@ -1842,7 +1877,7 @@ export async function readDocumentationResource(uri: string) {
     // Format files for better readability
     let formattedContent = content;
     if (doc.relFile && doc.relFile.endsWith('.js') && libraryId === '/openui5-api') {
-      formattedContent = formatJSDocContent(content, doc.title || '');
+      formattedContent = formatJSDocContent(content, doc.relFile, doc.title || '');
     } else if (libraryId === '/openui5-samples') {
       formattedContent = formatSampleContent(content, doc.relFile, doc.title || '');
     } else if (getDocUrlConfig(libraryId)) {
@@ -1918,4 +1953,4 @@ export async function searchCommunity(query: string, minKudos = 1, k = 30): Prom
       error: `Error searching SAP Community: ${error?.message || 'Unknown error'}. Please try again later.` 
     };
   }
-} 
+}

--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -14,13 +14,13 @@ export type SourceMeta = {
   sourcePath?: string;
   baseUrl?: string;
   pathPattern?: string;
-  anchorStyle?: 'docsify' | 'github' | 'custom';
+  anchorStyle?: 'docsify' | 'github' | 'custom' | 'sap-help';
 };
 
 export type DocUrlConfig = {
   baseUrl: string;
   pathPattern: string;
-  anchorStyle: 'docsify' | 'github' | 'custom';
+  anchorStyle: 'docsify' | 'github' | 'custom' | 'sap-help';
 };
 
 export type Metadata = {

--- a/src/lib/sapHelp.ts
+++ b/src/lib/sapHelp.ts
@@ -1,4 +1,5 @@
-import { 
+import { createHash } from "node:crypto";
+import {
   SearchResponse, 
   SearchResult, 
   SapHelpSearchResponse, 
@@ -24,6 +25,38 @@ function ensureAbsoluteUrl(url: string): string {
   // Ensure leading slash for relative URLs
   const cleanUrl = url.startsWith('/') ? url : '/' + url;
   return BASE + cleanUrl;
+}
+
+function validLoio(loio?: string): string | null {
+  if (!loio || loio === 'undefined' || loio === 'null') {
+    return null;
+  }
+
+  return loio;
+}
+
+function deriveSapHelpId(hit: any, index = 0): string {
+  const loio = validLoio(hit.loio);
+  if (loio) {
+    return loio;
+  }
+
+  const absoluteUrl = hit.url ? ensureAbsoluteUrl(hit.url) : '';
+  let slug = '';
+  try {
+    const url = new URL(absoluteUrl || BASE);
+    slug = decodeURIComponent(url.pathname.split('/').filter(Boolean).pop() || '')
+      .replace(/\.(?:html?|pdf)$/i, '')
+      .replace(/[^A-Za-z0-9_-]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 80);
+  } catch {
+    // Fall back to a hash-only id below.
+  }
+
+  const hashInput = absoluteUrl || hit.title || String(index);
+  const hash = createHash('sha1').update(hashInput).digest('hex').slice(0, 12);
+  return slug ? `url-${slug}-${hash}` : `url-${hash}`;
 }
 
 function parseDocsPathParts(urlOrPath: string): { productUrlSeg: string; deliverableLoio: string } {
@@ -81,34 +114,43 @@ export async function searchSapHelp(query: string): Promise<SearchResponse> {
     }
 
     // Store the search results for later retrieval
-    const searchResults: SearchResult[] = results.map((hit, index) => ({
-      library_id: `sap-help-${hit.loio}`,
-      topic: '',
-      id: `sap-help-${hit.loio}`,
-      title: hit.title,
-      url: ensureAbsoluteUrl(hit.url),
-      snippet: `${hit.snippet || hit.title} — Product: ${hit.product || hit.productId || "Unknown"} (${hit.version || hit.versionId || "Latest"})`,
-      score: 0,
-      metadata: {
-        source: "help",
-        loio: hit.loio,
-        product: hit.product || hit.productId,
-        version: hit.version || hit.versionId,
-        rank: index + 1
-      },
-      // Legacy fields for backward compatibility
-      description: `${hit.snippet || hit.title} — Product: ${hit.product || hit.productId || "Unknown"} (${hit.version || hit.versionId || "Latest"})`,
-      totalSnippets: 1,
-      source: "help"
-    }));
+    const searchResults: SearchResult[] = results.map((hit, index) => {
+      const helpId = deriveSapHelpId(hit, index);
+
+      return {
+        library_id: `sap-help-${helpId}`,
+        topic: '',
+        id: `sap-help-${helpId}`,
+        title: hit.title,
+        url: ensureAbsoluteUrl(hit.url),
+        snippet: `${hit.snippet || hit.title} — Product: ${hit.product || hit.productId || "Unknown"} (${hit.version || hit.versionId || "Latest"})`,
+        score: 0,
+        metadata: {
+          source: "help",
+          loio: validLoio(hit.loio),
+          product: hit.product || hit.productId,
+          version: hit.version || hit.versionId,
+          rank: index + 1
+        },
+        // Legacy fields for backward compatibility
+        description: `${hit.snippet || hit.title} — Product: ${hit.product || hit.productId || "Unknown"} (${hit.version || hit.versionId || "Latest"})`,
+        totalSnippets: 1,
+        source: "help"
+      };
+    });
 
     // Store the full search results in a simple cache for retrieval
     // In a real implementation, you might want a more sophisticated cache
     if (!global.sapHelpSearchCache) {
       global.sapHelpSearchCache = new Map();
     }
-    results.forEach(hit => {
-      global.sapHelpSearchCache!.set(hit.loio, hit);
+    results.forEach((hit, index) => {
+      const helpId = deriveSapHelpId(hit, index);
+      global.sapHelpSearchCache!.set(helpId, hit);
+      const loio = validLoio(hit.loio);
+      if (loio) {
+        global.sapHelpSearchCache!.set(loio, hit);
+      }
     });
 
     // Format response similar to other search functions
@@ -151,14 +193,14 @@ export async function searchSapHelp(query: string): Promise<SearchResponse> {
 export async function getSapHelpContent(resultId: string): Promise<string> {
   try {
     // Extract loio from the result ID
-    const loio = resultId.replace('sap-help-', '');
-    if (!loio || loio === resultId) {
+    const helpId = resultId.replace('sap-help-', '');
+    if (!helpId || helpId === resultId) {
       throw new Error("Invalid SAP Help result ID. Use an ID from sap_help_search results.");
     }
 
     // First try to get from cache
     const cache = global.sapHelpSearchCache || new Map();
-    let hit = cache.get(loio);
+    let hit = cache.get(helpId);
 
     if (!hit) {
       // If not in cache, search again to get the full hit data
@@ -167,7 +209,7 @@ export async function getSapHelpContent(resultId: string): Promise<string> {
         state: "PRODUCTION,TEST,DRAFT",
         product: "",
         version: "",
-        q: loio, // Search by loio to find the specific document
+        q: helpId, // Search by LOIO or stable derived id to find the specific document
         to: "19",
         area: "content",
         advancedSearch: "0",
@@ -190,11 +232,32 @@ export async function getSapHelpContent(resultId: string): Promise<string> {
 
       const searchData: SapHelpSearchResponse = await searchResponse.json();
       const results = searchData?.data?.results || [];
-      hit = results.find(r => r.loio === loio);
+      hit = results.find((r, index) => validLoio(r.loio) === helpId || deriveSapHelpId(r, index) === helpId);
 
       if (!hit) {
-        throw new Error(`Document with loio ${loio} not found`);
+        throw new Error(`SAP Help document ${helpId} not found`);
       }
+    }
+
+    if (!validLoio(hit.loio)) {
+      const fullContent = `# ${hit.title}
+
+**Source:** SAP Help Portal
+**URL:** ${ensureAbsoluteUrl(hit.url)}
+**Product:** ${hit.product || hit.productId || "Unknown"}
+**Version:** ${hit.version || hit.versionId || "Latest"}
+**Language:** ${hit.language || "en-US"}
+${hit.snippet ? `**Summary:** ${hit.snippet}` : ''}
+
+---
+
+This SAP Help search result does not expose a LOIO page id through the search API, so only the searchable metadata and canonical URL are available.
+
+---
+
+*This content is from the SAP Help Portal and represents official SAP documentation.*`;
+
+      return truncateContent(fullContent).content;
     }
 
     // Prepare metadata request parameters

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -1,5 +1,5 @@
 // Unified ABAP/RAP search using FTS5 with optional online sources
-import { searchFTS } from "./searchDb.js";
+import { lookupExactDocs, searchFTS } from "./searchDb.js";
 import { CONFIG } from "./config.js";
 import { loadMetadata, getSourceBoosts, expandQueryTerms, getContextBoosts, getAllContextBoosts } from "./metadata.js";
 import { searchSapHelp } from "./sapHelp.js";
@@ -172,6 +172,10 @@ function extractSourceId(libraryIdOrPath: string): string {
   return libraryIdOrPath;
 }
 
+function normalizeSourceFilter(source: string): string {
+  return source.replace(/^\/+/, '').trim();
+}
+
 // Create a promise that rejects after timeout
 function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
   return Promise.race([
@@ -328,11 +332,22 @@ export async function search(
   
   // Detect implementation intent for sample boosting
   const wantsImplementation = hasImplementationIntent(query);
+
+  const sourceFilters = sources?.length
+    ? new Set(sources.map(normalizeSourceFilter).filter(Boolean))
+    : null;
+  const ftsFilters = sourceFilters
+    ? { libraries: [...sourceFilters].map(sourceId => `/${sourceId}`) }
+    : {};
+
+  for (const r of lookupExactDocs(query, ftsFilters, Math.min(k, 10))) {
+    seen.set(r.id, r);
+  }
   
   // Search offline FTS database with all query variants (union approach)
   for (const variant of queryVariants) {
     try {
-      const rows = searchFTS(variant, {}, k * 2); // Get more candidates for filtering
+      const rows = searchFTS(variant, ftsFilters, k * 2); // Get more candidates for filtering
       for (const r of rows) {
         if (!seen.has(r.id)) {
           seen.set(r.id, r);
@@ -348,10 +363,10 @@ export async function search(
   let rows = Array.from(seen.values());
   
   // Filter by specific sources if provided
-  if (sources && sources.length > 0) {
+  if (sourceFilters) {
     rows = rows.filter(r => {
       const sourceId = extractSourceId(r.libraryId || r.id);
-      return sources.includes(sourceId);
+      return sourceFilters.has(sourceId);
     });
   }
   

--- a/src/lib/searchDb.ts
+++ b/src/lib/searchDb.ts
@@ -200,6 +200,67 @@ export function searchFTS(userQuery: string, filters: Filters = {}, limit = 20):
 }
 
 /**
+ * Lookup exact document titles/IDs before FTS prefix ranking.
+ * This catches keyword-document IDs such as ABAPSELECT, where FTS prefix matching
+ * can otherwise rank ABAPSELECTION-* pages first.
+ */
+export function lookupExactDocs(userQuery: string, filters: Filters = {}, limit = 10): FTSResult[] {
+  const exact = userQuery.trim().replace(/^\/+/, '');
+  if (!/^[A-Za-z0-9_-]{3,100}$/.test(exact)) {
+    return [];
+  }
+
+  const database = openDb();
+  const conditions = [
+    "(lower(title) = lower(?) OR lower(id) = lower(?) OR lower(id) LIKE lower(?))"
+  ];
+  const params: any[] = [exact, exact.startsWith('/') ? exact : `/${exact}`, `%/${exact}`];
+
+  if (filters.libraries?.length) {
+    const placeholders = filters.libraries.map(() => "?").join(",");
+    conditions.push(`libraryId IN (${placeholders})`);
+    params.push(...filters.libraries);
+  }
+
+  if (filters.types?.length) {
+    const placeholders = filters.types.map(() => "?").join(",");
+    conditions.push(`type IN (${placeholders})`);
+    params.push(...filters.types);
+  }
+
+  const sql = `
+    SELECT
+      id, libraryId, type, title, description, relFile, snippetCount,
+      title AS highlight,
+      -999.0 AS bm25Score
+    FROM docs
+    WHERE ${conditions.join(" AND ")}
+    ORDER BY length(id), id
+    LIMIT ?
+  `;
+
+  try {
+    const stmt = database.prepare(sql);
+    const rows = stmt.all(...params, limit) as any[];
+
+    return rows.map(r => ({
+      id: r.id,
+      libraryId: r.libraryId,
+      type: r.type,
+      title: r.title,
+      description: r.description,
+      relFile: r.relFile,
+      snippetCount: r.snippetCount,
+      bm25Score: Number(r.bm25Score),
+      highlight: r.highlight || r.title
+    }));
+  } catch (error) {
+    console.warn("Exact doc lookup failed:", error);
+    return [];
+  }
+}
+
+/**
  * Get database stats for monitoring
  */
 export function getFTSStats(): { rowCount: number; dbSize: number; mtime: string } | null {

--- a/src/lib/sourceContent.ts
+++ b/src/lib/sourceContent.ts
@@ -1,0 +1,59 @@
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import { getSourcePath } from "./metadata.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+let projectRoot: string | null = null;
+
+export function getProjectRoot(): string {
+  if (projectRoot) {
+    return projectRoot;
+  }
+
+  let current = __dirname;
+  while (current !== path.dirname(current)) {
+    if (fs.existsSync(path.join(current, "package.json"))) {
+      projectRoot = current;
+      return projectRoot;
+    }
+    current = path.dirname(current);
+  }
+
+  projectRoot = path.resolve(__dirname, "../../..");
+  return projectRoot;
+}
+
+export function readSourceContentSync(libraryId: string, relFile: string): string | null {
+  if (!relFile) {
+    return null;
+  }
+
+  const sourcePath = getSourcePath(libraryId);
+  if (!sourcePath) {
+    return null;
+  }
+
+  const absPath = path.join(getProjectRoot(), "sources", sourcePath, relFile);
+  try {
+    return fs.readFileSync(absPath, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+export function extractSourceUrlFromText(text: string): string | null {
+  const match = text.match(/\*\*URL:?\*\*:?\s*(https?:\/\/[^\s)]+)/i);
+  if (match) {
+    return normalizeExtractedUrl(match[1]);
+  }
+
+  const plainMatch = text.match(/\bURL:\s*(https?:\/\/[^\s)]+)/i);
+  return plainMatch ? normalizeExtractedUrl(plainMatch[1]) : null;
+}
+
+function normalizeExtractedUrl(url: string): string {
+  return url.replace(/[>,.;]+$/, "");
+}

--- a/src/lib/url-generation/BaseUrlGenerator.ts
+++ b/src/lib/url-generation/BaseUrlGenerator.ts
@@ -87,13 +87,20 @@ export abstract class BaseUrlGenerator {
     section: string;
     anchor: string | null;
   }): string | null {
-    // Extract just the filename without directory path to avoid duplication with pathPattern
-    const fileName = context.relFile
+    let relPath = context.relFile
+      .replace(/\\/g, '/')
       .replace(/\.mdx?$/, '')
-      .replace(/\.html?$/, '')
-      .replace(/.*\//, ''); // Remove directory path, keep only filename
+      .replace(/\.html?$/, '');
+
+    const patternPrefix = this.config.pathPattern
+      .split('{file}')[0]
+      .replace(/^\/+|\/+$/g, '');
+
+    if (patternPrefix && relPath.startsWith(`${patternPrefix}/`)) {
+      relPath = relPath.slice(patternPrefix.length + 1);
+    }
     
-    let urlPath = this.config.pathPattern.replace('{file}', fileName);
+    let urlPath = this.config.pathPattern.replace('{file}', relPath);
     
     // Add anchor if available
     if (context.anchor) {

--- a/src/lib/url-generation/README.md
+++ b/src/lib/url-generation/README.md
@@ -89,19 +89,18 @@ const url = buildUrl('https://example.com', 'docs', 'guides', 'tutorial');
 - Automatically detects sections: guides, features, tutorials, environments
 - Example: `https://sap.github.io/cloud-sdk/docs/js/guides/remote-debugging`
 
-### SAPUI5 (`/sapui5`, `/openui5-api`, `/openui5-samples`)
+### SAPUI5 and OpenUI5 (`/sapui5`, `/openui5-api`, `/openui5-samples`)
 
-- **SAPUI5 Docs**: Uses topic IDs from frontmatter or filename
-- **API Docs**: Uses control/namespace paths
-- **Samples**: Uses sample-specific paths
-- Example: `https://ui5.sap.com/#/topic/123e4567-e89b-12d3-a456-426614174000`
+- **SAPUI5 Docs**: Uses `https://ui5.sap.com/#/topic/...` topic IDs from frontmatter, LOIO/copy comments, or index links
+- **OpenUI5 API Docs**: Uses `https://sdk.openui5.org/#/api/...` control/namespace paths
+- **OpenUI5 Samples**: Uses `https://sdk.openui5.org/#/entity/.../sample/...` sample-specific paths
 
 ### CAP (`/cap`)
 
-- Uses docsify-style URLs with `#/` fragments
+- Uses direct capire VitePress URLs
 - Supports frontmatter `id` and `slug` fields
 - Handles CDS reference docs, tutorials, and guides
-- Example: `https://cap.cloud.sap/docs/#/guides/getting-started`
+- Example: `https://cap.cloud.sap/docs/guides/services/providing-services`
 
 ### wdi5 (`/wdi5`)
 
@@ -219,4 +218,3 @@ URL generation is configured through the metadata system. Each source should hav
 1. Confirm the source ID matches between metadata and dispatcher
 2. Verify the URL generation function is exported and imported correctly
 3. Check that the function returns non-null values for valid inputs
-

--- a/src/lib/url-generation/architecture-center.ts
+++ b/src/lib/url-generation/architecture-center.ts
@@ -22,7 +22,7 @@ export class ArchitectureCenterUrlGenerator extends BaseUrlGenerator {
 
     if (slug) {
       // Slug-based URLs are complete identifiers — don't append content anchors
-      return this.config.baseUrl + slug;
+      return this.buildUrl(this.config.baseUrl, slug);
     }
 
     return null;

--- a/src/lib/url-generation/cap.ts
+++ b/src/lib/url-generation/cap.ts
@@ -6,6 +6,105 @@
 import { BaseUrlGenerator, UrlGenerationContext } from './BaseUrlGenerator.js';
 import { FrontmatterData } from './utils.js';
 import { DocUrlConfig } from '../metadata.js';
+import { getProjectRoot } from '../sourceContent.js';
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+
+const CAP_ROUTE_OVERRIDES: Record<string, string> = {
+  'about/best-practices.md': 'get-started/concepts',
+  'about/features.md': 'get-started/feature-matrix',
+  'about/index.md': 'get-started/features',
+  'advanced/fiori.md': 'guides/uis/fiori',
+  'advanced/hana.md': 'guides/databases/hana-native',
+  'advanced/hybrid-testing.md': 'tools/cds-bind',
+  'advanced/odata.md': 'guides/protocols/odata',
+  'advanced/performance-modeling.md': 'guides/databases/performance',
+  'advanced/publishing-apis/asyncapi.md': 'guides/protocols/asyncapi',
+  'advanced/publishing-apis/index.md': 'guides/protocols',
+  'advanced/publishing-apis/openapi.md': 'guides/protocols/openapi',
+  'get-started/in-a-nutshell.md': 'get-started/bookshop',
+  'get-started/learning-sources.md': 'get-started/learn-more',
+  'get-started/troubleshooting.md': 'get-started/get-help',
+  'guides/providing-services.md': 'guides/services/providing-services',
+  'guides/using-services.md': 'guides/services/consuming-services',
+  'guides/databases.md': 'guides/databases',
+  'guides/databases-h2.md': 'guides/databases/h2',
+  'guides/databases-hana.md': 'guides/databases/hana',
+  'guides/databases-postgres.md': 'guides/databases/postgres',
+  'guides/databases-sqlite.md': 'guides/databases/sqlite',
+  'guides/deployment/cicd.md': 'guides/deploy/cicd',
+  'guides/deployment/custom-builds.md': 'guides/deploy/build',
+  'guides/deployment/health-checks.md': 'guides/deploy/health-checks',
+  'guides/deployment/index.md': 'guides/deploy',
+  'guides/deployment/microservices.md': 'guides/deploy/microservices',
+  'guides/deployment/to-cf.md': 'guides/deploy/to-cf',
+  'guides/deployment/to-kyma.md': 'guides/deploy/to-kyma',
+  'guides/domain-modeling.md': 'guides/domain',
+  'guides/temporal-data.md': 'guides/domain/temporal-data',
+  'guides/i18n.md': 'guides/uis/i18n',
+  'guides/localized-data.md': 'guides/uis/localized-data',
+  'guides/messaging/event-broker.md': 'guides/events/event-hub',
+  'guides/messaging/event-mesh.md': 'guides/events/event-mesh',
+  'guides/messaging/index.md': 'guides/events',
+  'guides/messaging/s4.md': 'guides/events/s4',
+  'guides/messaging/task-queues.md': 'guides/events/event-queues',
+  'guides/data-privacy/annotations.md': 'guides/security/dpp-annotations',
+  'guides/data-privacy/audit-logging.md': 'guides/security/dpp-audit-logging',
+  'guides/data-privacy/drm.md': 'guides/security/dpp-drm',
+  'guides/data-privacy/index.md': 'guides/security/data-privacy',
+  'guides/data-privacy/pdm.md': 'guides/security/dpp-pdm',
+  'guides/extensibility/composition.md': 'guides/integration/reuse-and-compose',
+  'guides/security/aspects.md': 'guides/security/data-protection',
+  'guides/security/data-protection-privacy.md': 'guides/security/data-protection'
+};
+
+const CAP_GITHUB_BLOB_BASE = 'https://github.com/capire/docs/blob';
+let capGitRef: string | null | undefined;
+
+const CAP_REPO_ONLY_PATTERNS = [
+  /^(?:CODE_OF_CONDUCT|CONTRIBUTING|README|menu)\.md$/i,
+  /(?:^|\/)_menu\.md$/i,
+  /(?:^|\/)assets\/.*\.md$/i,
+  /^tools\/assets\/help\/.*\.md$/i,
+  /^about\/bad-practices\.md$/i,
+  /^advanced\/analytics\.md$/i,
+  /^advanced\/index\.md$/i,
+  /^guides\/querying(?:\.md|\/)/i,
+  /^guides\/uis\/analytics\.md$/i,
+  /^java\/operating-applications\/sizing\.md$/i
+];
+
+function encodePathForGithub(relFile: string): string {
+  return relFile
+    .split('/')
+    .map(segment => encodeURIComponent(segment))
+    .join('/');
+}
+
+function getCapGitRef(): string {
+  if (capGitRef !== undefined) {
+    return capGitRef || 'main';
+  }
+
+  try {
+    capGitRef = execFileSync('git', ['-C', path.join(getProjectRoot(), 'sources', 'cap-docs'), 'rev-parse', 'HEAD'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore']
+    }).trim();
+  } catch {
+    capGitRef = null;
+  }
+
+  return capGitRef || 'main';
+}
+
+function buildCapGithubBlobUrl(relFile: string): string {
+  return `${CAP_GITHUB_BLOB_BASE}/${getCapGitRef()}/${encodePathForGithub(relFile)}`;
+}
+
+function isCapRepoOnlyFile(relFile: string): boolean {
+  return CAP_REPO_ONLY_PATTERNS.some(pattern => pattern.test(relFile));
+}
 
 export interface CapUrlOptions {
   relFile: string;
@@ -25,28 +124,17 @@ export class CapUrlGenerator extends BaseUrlGenerator {
     section: string;
     anchor: string | null;
   }): string | null {
-    const identifier = this.getIdentifierFromFrontmatter(context.frontmatter);
-    
-    // Use frontmatter slug or id for URL generation
-    if (identifier) {
-      const section = this.extractCapSection(context.relFile);
-      
-      if (section) {
-        return this.buildDocsifyUrl(`${section}/${identifier}`);
-      }
-      
-      return this.buildDocsifyUrl(identifier);
+    const normalizedRelFile = context.relFile.replace(/\\/g, '/');
+
+    if (isCapRepoOnlyFile(normalizedRelFile)) {
+      return buildCapGithubBlobUrl(normalizedRelFile);
     }
-    
-    // Fallback to filename-based URL
-    const fileName = this.getCleanFileName(context.relFile);
-    const section = this.extractCapSection(context.relFile);
-    
-    if (section) {
-      return this.buildDocsifyUrl(`${section}/${fileName}`);
-    }
-    
-    return this.buildDocsifyUrl(fileName);
+
+    const route = CAP_ROUTE_OVERRIDES[normalizedRelFile] || normalizedRelFile
+      .replace(/\.md$/, '')
+      .replace(/(?:^|\/)(?:index|README)$/i, '');
+
+    return this.buildUrl(this.config.baseUrl, 'docs', route);
   }
   
   /**
@@ -81,14 +169,6 @@ export class CapUrlGenerator extends BaseUrlGenerator {
     return this.extractCapSection(relFile);
   }
   
-  /**
-   * Override to use CAP-specific docsify URL building
-   * CAP URLs have a /docs/ prefix before the # fragment
-   */
-  protected buildDocsifyUrl(path: string): string {
-    const cleanPath = path.startsWith('/') ? path.slice(1) : path;
-    return `${this.config.baseUrl}/docs/#/${cleanPath}`;
-  }
 }
 
 // Convenience functions for backward compatibility
@@ -114,4 +194,3 @@ export function generateCapCdsUrl(options: CapUrlOptions): string | null {
 export function generateCapTutorialUrl(options: CapUrlOptions): string | null {
   return generateCapUrl(options); // Now handled by the main generator
 }
-

--- a/src/lib/url-generation/cap.ts
+++ b/src/lib/url-generation/cap.ts
@@ -8,9 +8,12 @@ import { FrontmatterData } from './utils.js';
 import { DocUrlConfig } from '../metadata.js';
 import { getProjectRoot } from '../sourceContent.js';
 import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
 import path from 'node:path';
 
-const CAP_ROUTE_OVERRIDES: Record<string, string> = {
+const CAP_SOURCE_ROOT = path.join(getProjectRoot(), 'sources', 'cap-docs');
+
+const CAP_LEGACY_ROUTE_MIGRATIONS: Record<string, string> = {
   'about/best-practices.md': 'get-started/concepts',
   'about/features.md': 'get-started/feature-matrix',
   'about/index.md': 'get-started/features',
@@ -74,6 +77,8 @@ const CAP_REPO_ONLY_PATTERNS = [
   /^java\/operating-applications\/sizing\.md$/i
 ];
 
+let capMenuRouteMap: Map<string, string> | null | undefined;
+
 function encodePathForGithub(relFile: string): string {
   return relFile
     .split('/')
@@ -106,6 +111,105 @@ function isCapRepoOnlyFile(relFile: string): boolean {
   return CAP_REPO_ONLY_PATTERNS.some(pattern => pattern.test(relFile));
 }
 
+function toPosixPath(value: string): string {
+  return value.replace(/\\/g, '/');
+}
+
+function trimLeadingParentSegments(value: string): string {
+  let result = value;
+  while (result.startsWith('../')) {
+    result = result.slice(3);
+  }
+  return result.replace(/^\.\//, '');
+}
+
+function findCapMenuFiles(dir: string): string[] {
+  const result: string[] = [];
+
+  try {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (entry.name === '.git' || entry.name === 'node_modules') {
+        continue;
+      }
+
+      const absPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        result.push(...findCapMenuFiles(absPath));
+      } else if (entry.name === 'menu.md' || entry.name === '_menu.md') {
+        result.push(absPath);
+      }
+    }
+  } catch {
+    // Ignore missing or sparse source directories.
+  }
+
+  return result;
+}
+
+function routeToRelFile(route: string): string {
+  if (route.endsWith('/')) {
+    const cleanRoute = route.replace(/\/$/, '');
+    return cleanRoute ? `${cleanRoute}/index.md` : 'index.md';
+  }
+
+  const cleanRoute = route.replace(/\/$/, '');
+  if (!cleanRoute) {
+    return 'index.md';
+  }
+  return cleanRoute.endsWith('.md') ? cleanRoute : `${cleanRoute}.md`;
+}
+
+function routeToPublicPath(route: string): string {
+  return route
+    .replace(/\.md$/i, '')
+    .replace(/(?:^|\/)(?:index|README)$/i, '')
+    .replace(/\/$/, '');
+}
+
+function buildCapMenuRouteMap(): Map<string, string> {
+  const routeMap = new Map<string, string>();
+  for (const menuFile of findCapMenuFiles(CAP_SOURCE_ROOT)) {
+    const menuDir = toPosixPath(path.relative(CAP_SOURCE_ROOT, path.dirname(menuFile)));
+    const menuContent = fs.readFileSync(menuFile, 'utf8');
+
+    for (const line of menuContent.split(/\r?\n/)) {
+      const linkMatch = line.match(/\[[^\]]+\]\(([^)]+)\)/);
+      const rawLink = linkMatch?.[1]?.trim();
+      if (!rawLink || rawLink.startsWith('#') || /^[a-z][a-z0-9+.-]*:/i.test(rawLink)) {
+        continue;
+      }
+
+      const linkWithoutAnchor = rawLink.split('#')[0].trim();
+      if (!linkWithoutAnchor || /_menu\.md$/i.test(linkWithoutAnchor)) {
+        continue;
+      }
+
+      const route = trimLeadingParentSegments(toPosixPath(path.posix.normalize(
+        linkWithoutAnchor.startsWith('/')
+          ? linkWithoutAnchor.slice(1)
+          : path.posix.join(menuDir, linkWithoutAnchor)
+      )));
+      const relFile = routeToRelFile(route);
+      const publicPath = routeToPublicPath(route);
+      routeMap.set(relFile, publicPath);
+    }
+  }
+
+  return routeMap;
+}
+
+function getCapMenuRoute(relFile: string): string | null {
+  if (capMenuRouteMap === undefined) {
+    try {
+      capMenuRouteMap = buildCapMenuRouteMap();
+    } catch {
+      capMenuRouteMap = null;
+    }
+  }
+
+  return capMenuRouteMap?.get(relFile) || null;
+}
+
 export interface CapUrlOptions {
   relFile: string;
   content: string;
@@ -130,7 +234,7 @@ export class CapUrlGenerator extends BaseUrlGenerator {
       return buildCapGithubBlobUrl(normalizedRelFile);
     }
 
-    const route = CAP_ROUTE_OVERRIDES[normalizedRelFile] || normalizedRelFile
+    const route = CAP_LEGACY_ROUTE_MIGRATIONS[normalizedRelFile] || getCapMenuRoute(normalizedRelFile) || normalizedRelFile
       .replace(/\.md$/, '')
       .replace(/(?:^|\/)(?:index|README)$/i, '');
 

--- a/src/lib/url-generation/cloud-sdk.ts
+++ b/src/lib/url-generation/cloud-sdk.ts
@@ -6,6 +6,7 @@
 import { BaseUrlGenerator, UrlGenerationContext } from './BaseUrlGenerator.js';
 import { FrontmatterData } from './utils.js';
 import { DocUrlConfig } from '../metadata.js';
+import { buildDocusaurusPath } from './docusaurus.js';
 
 export interface CloudSdkUrlOptions {
   relFile: string;
@@ -25,44 +26,8 @@ export class CloudSdkUrlGenerator extends BaseUrlGenerator {
     section: string;
     anchor: string | null;
   }): string | null {
-    const identifier = this.getIdentifierFromFrontmatter(context.frontmatter);
-    
-    // Use frontmatter ID if available (preferred method)
-    if (identifier) {
-      // Special handling for AI SDK variants
-      if (this.isAiSdk()) {
-        return this.buildAiSdkUrl(context.relFile, identifier);
-      } else {
-        return this.buildUrl(this.config.baseUrl, context.section, identifier);
-      }
-    }
-    
-    return null;
-  }
-  
-  /**
-   * Check if this is an AI SDK variant
-   */
-  private isAiSdk(): boolean {
-    return this.libraryId.includes('-ai-');
-  }
-  
-  /**
-   * Build AI SDK specific URL with proper section handling
-   */
-  private buildAiSdkUrl(relFile: string, identifier: string): string {
-    // Extract section from the file path for AI SDK
-    if (this.isInDirectory(relFile, 'langchain')) {
-      return this.buildUrl(this.config.baseUrl, 'langchain', identifier);
-    } else if (this.isInDirectory(relFile, 'getting-started')) {
-      return this.buildUrl(this.config.baseUrl, 'getting-started', identifier);
-    } else if (this.isInDirectory(relFile, 'examples')) {
-      return this.buildUrl(this.config.baseUrl, 'examples', identifier);
-    }
-    
-    // Default behavior for other sections
-    const section = this.extractSection(relFile);
-    return this.buildUrl(this.config.baseUrl, section, identifier);
+    const route = buildDocusaurusPath(context.relFile, context.frontmatter);
+    return this.buildUrl(this.config.baseUrl, route);
   }
   
   /**
@@ -104,4 +69,3 @@ export function generateCloudSdkAiUrl(options: CloudSdkUrlOptions): string | nul
 export function generateCloudSdkUrlForLibrary(options: CloudSdkUrlOptions): string | null {
   return generateCloudSdkUrl(options);
 }
-

--- a/src/lib/url-generation/docusaurus.ts
+++ b/src/lib/url-generation/docusaurus.ts
@@ -1,0 +1,45 @@
+import { FrontmatterData } from './utils.js';
+
+export function stripMarkdownExtension(path: string): string {
+  return path.replace(/\.mdx?$/, '');
+}
+
+export function stripNumericPrefix(segment: string): string {
+  return segment.replace(/^\d+[-_]/, '');
+}
+
+export function removeIndexSegments(segments: string[]): string[] {
+  return segments.filter(segment => !/^(?:index|README)$/i.test(segment));
+}
+
+export function buildDocusaurusPath(relFile: string, frontmatterOrIdentifier?: FrontmatterData | string | null): string {
+  const frontmatter = typeof frontmatterOrIdentifier === 'object' ? frontmatterOrIdentifier : null;
+  const identifier = typeof frontmatterOrIdentifier === 'string'
+    ? frontmatterOrIdentifier
+    : frontmatter?.id || null;
+
+  const rawSegments = stripMarkdownExtension(relFile).split('/').filter(Boolean);
+  const normalizedSegments = removeIndexSegments(rawSegments.map(stripNumericPrefix));
+
+  if (frontmatter?.slug) {
+    const slug = String(frontmatter.slug).replace(/^\/+|\/+$/g, '');
+    if (String(frontmatter.slug).startsWith('/')) {
+      return slug;
+    }
+
+    return [...normalizedSegments.slice(0, -1), slug].filter(Boolean).join('/');
+  }
+
+  if (!identifier) {
+    return normalizedSegments.join('/');
+  }
+
+  const dirSegments = normalizedSegments.slice(0, -1);
+  const lastDirSegment = dirSegments[dirSegments.length - 1];
+
+  if (lastDirSegment === identifier) {
+    return dirSegments.join('/');
+  }
+
+  return [...dirSegments, identifier].join('/');
+}

--- a/src/lib/url-generation/dsag.ts
+++ b/src/lib/url-generation/dsag.ts
@@ -25,6 +25,16 @@ export class DsagUrlGenerator extends BaseUrlGenerator {
     section: string;
     anchor: string | null;
   }): string | null {
+    if (context.frontmatter.permalink) {
+      const permalink = context.frontmatter.permalink.startsWith('/')
+        ? context.frontmatter.permalink
+        : `/${context.frontmatter.permalink}`;
+      let url = this.config.baseUrl.replace(/\/$/, '') + permalink;
+      if (context.anchor) {
+        url += '#' + context.anchor;
+      }
+      return url;
+    }
     
     // Transform the relative file path for GitHub Pages
     // Remove docs/ prefix and .md extension, add trailing slash
@@ -37,9 +47,13 @@ export class DsagUrlGenerator extends BaseUrlGenerator {
     
     // Remove .md extension
     urlPath = urlPath.replace(/\.md$/, '');
+
+    if (/^(?:index|README)$/i.test(urlPath)) {
+      urlPath = '';
+    }
     
     // Build the final URL with trailing slash
-    let url = `${this.config.baseUrl}/${urlPath}/`;
+    let url = urlPath ? `${this.config.baseUrl}/${urlPath}/` : `${this.config.baseUrl}/`;
     
     // Add anchor if available
     if (context.anchor) {
@@ -65,6 +79,9 @@ export function generateDsagUrl(relFile: string, content: string): string {
     urlPath = urlPath.substring(5);
   }
   urlPath = urlPath.replace(/\.md$/, '');
+  if (/^(?:index|README)$/i.test(urlPath)) {
+    urlPath = '';
+  }
   
-  return `${baseUrl}/${urlPath}/`;
+  return urlPath ? `${baseUrl}/${urlPath}/` : `${baseUrl}/`;
 }

--- a/src/lib/url-generation/github-blob.ts
+++ b/src/lib/url-generation/github-blob.ts
@@ -1,0 +1,30 @@
+import { BaseUrlGenerator, UrlGenerationContext } from './BaseUrlGenerator.js';
+import { FrontmatterData } from './utils.js';
+
+function encodePath(path: string): string {
+  return path
+    .split('/')
+    .map(part => encodeURIComponent(part))
+    .join('/');
+}
+
+export class GithubBlobUrlGenerator extends BaseUrlGenerator {
+  protected generateSourceSpecificUrl(context: UrlGenerationContext & {
+    frontmatter: FrontmatterData;
+    section: string;
+    anchor: string | null;
+  }): string | null {
+    const relPath = encodePath(context.relFile);
+    let url = this.buildUrl(this.config.baseUrl, relPath);
+
+    if (!/\.mdx?$/i.test(context.relFile)) {
+      url += '?plain=1';
+    }
+
+    if (context.anchor) {
+      url += `#${context.anchor}`;
+    }
+
+    return url;
+  }
+}

--- a/src/lib/url-generation/index.ts
+++ b/src/lib/url-generation/index.ts
@@ -14,6 +14,11 @@ import { TerraformBtpUrlGenerator } from './terraform-btp.js';
 import { GenericUrlGenerator } from './GenericUrlGenerator.js';
 import { ArchitectureCenterUrlGenerator } from './architecture-center.js';
 import { BaseUrlGenerator } from './BaseUrlGenerator.js';
+import { GithubBlobUrlGenerator } from './github-blob.js';
+import { MkDocsUrlGenerator } from './mkdocs.js';
+import { SapHelpLoioUrlGenerator } from './sap-help-loio.js';
+import { Ui5TypeScriptUrlGenerator } from './ui5-typescript.js';
+import { Ui5WebComponentsUrlGenerator } from './ui5-webcomponents.js';
 
 export interface UrlGenerationOptions {
   libraryId: string;
@@ -54,16 +59,22 @@ const URL_GENERATORS: Record<string, new (libraryId: string, config: DocUrlConfi
   '/abap-docs-cloud': AbapUrlGenerator,
   
   // Generic sources
-  '/ui5-tooling': GenericUrlGenerator,
-  '/cloud-mta-build-tool': GenericUrlGenerator,
-  '/ui5-webcomponents': GenericUrlGenerator,
-  '/ui5-typescript': GenericUrlGenerator,
-  '/ui5-cc-spreadsheetimporter': GenericUrlGenerator,
-  '/abap-cheat-sheets': GenericUrlGenerator,
-  '/sap-styleguides': GenericUrlGenerator,
-  '/abap-fiori-showcase': GenericUrlGenerator,
-  '/cap-fiori-showcase': GenericUrlGenerator,
+  '/ui5-tooling': MkDocsUrlGenerator,
+  '/cloud-mta-build-tool': MkDocsUrlGenerator,
+  '/ui5-webcomponents': Ui5WebComponentsUrlGenerator,
+  '/ui5-typescript': Ui5TypeScriptUrlGenerator,
+  '/ui5-cc-spreadsheetimporter': MkDocsUrlGenerator,
+  '/abap-cheat-sheets': GithubBlobUrlGenerator,
+  '/sap-styleguides': GithubBlobUrlGenerator,
+  '/abap-fiori-showcase': GithubBlobUrlGenerator,
+  '/cap-fiori-showcase': GithubBlobUrlGenerator,
+  '/abap-platform-rap-opensap': GithubBlobUrlGenerator,
+  '/cloud-abap-rap': GithubBlobUrlGenerator,
+  '/abap-platform-reuse-services': GithubBlobUrlGenerator,
+  '/teched2025-dt260': GithubBlobUrlGenerator,
   '/terraform-provider-btp': TerraformBtpUrlGenerator,
+  '/btp-cloud-platform': SapHelpLoioUrlGenerator,
+  '/sap-artificial-intelligence': SapHelpLoioUrlGenerator,
 
   // SAP Architecture Center
   '/architecture-center': ArchitectureCenterUrlGenerator,
@@ -135,6 +146,11 @@ export { DsagUrlGenerator } from './dsag.js';
 export { TerraformBtpUrlGenerator } from './terraform-btp.js';
 export { GenericUrlGenerator } from './GenericUrlGenerator.js';
 export { ArchitectureCenterUrlGenerator } from './architecture-center.js';
+export { GithubBlobUrlGenerator } from './github-blob.js';
+export { MkDocsUrlGenerator } from './mkdocs.js';
+export { SapHelpLoioUrlGenerator } from './sap-help-loio.js';
+export { Ui5TypeScriptUrlGenerator } from './ui5-typescript.js';
+export { Ui5WebComponentsUrlGenerator } from './ui5-webcomponents.js';
 
 // Re-export convenience functions for backward compatibility
 export { generateCloudSdkUrl, generateCloudSdkAiUrl, generateCloudSdkUrlForLibrary } from './cloud-sdk.js';

--- a/src/lib/url-generation/mkdocs.ts
+++ b/src/lib/url-generation/mkdocs.ts
@@ -1,0 +1,31 @@
+import { BaseUrlGenerator, UrlGenerationContext } from './BaseUrlGenerator.js';
+import { FrontmatterData } from './utils.js';
+
+function stripMarkdownExtension(path: string): string {
+  return path.replace(/\.mdx?$/, '');
+}
+
+function dropIndex(path: string): string {
+  return path.replace(/(?:^|\/)(?:index|README)$/i, '');
+}
+
+function ensureTrailingSlash(url: string): string {
+  return url.endsWith('/') ? url : `${url}/`;
+}
+
+export class MkDocsUrlGenerator extends BaseUrlGenerator {
+  protected generateSourceSpecificUrl(context: UrlGenerationContext & {
+    frontmatter: FrontmatterData;
+    section: string;
+    anchor: string | null;
+  }): string | null {
+    const docPath = dropIndex(stripMarkdownExtension(context.relFile));
+    let url = ensureTrailingSlash(this.buildUrl(this.config.baseUrl, docPath));
+
+    if (context.anchor) {
+      url += `#${context.anchor}`;
+    }
+
+    return url;
+  }
+}

--- a/src/lib/url-generation/sap-help-loio.ts
+++ b/src/lib/url-generation/sap-help-loio.ts
@@ -1,0 +1,76 @@
+import { BaseUrlGenerator, UrlGenerationContext } from './BaseUrlGenerator.js';
+import { FrontmatterData } from './utils.js';
+
+const BTP_DELIVERABLE = '65de2977205c403bbc107264b8eccf4b';
+const AI_CORE_DELIVERABLE = '2d6c5984063c40a59eda62f4a9135bee';
+const AI_LAUNCHPAD_DELIVERABLE = '92d77f26188e4582897b9106b9cb72e0';
+
+function extractLoio(content: string, relFile: string): string | null {
+  const commentMatch = content.match(/<!--\s*loio([a-f0-9]{32})\s*-->/i);
+  if (commentMatch) {
+    return commentMatch[1];
+  }
+
+  const fileMatch = relFile.match(/([a-f0-9]{32})\.md$/i);
+  if (fileMatch) {
+    return fileMatch[1];
+  }
+
+  return null;
+}
+
+function isIndexPage(relFile: string): boolean {
+  return !relFile || /(?:^|\/)(?:index|README)\.md$/i.test(relFile);
+}
+
+export class SapHelpLoioUrlGenerator extends BaseUrlGenerator {
+  public generateUrl(context: UrlGenerationContext): string | null {
+    return this.generateSourceSpecificUrl({
+      ...context,
+      frontmatter: this.parseFrontmatter(context.content),
+      section: this.extractSection(context.relFile),
+      anchor: null
+    });
+  }
+
+  protected generateSourceSpecificUrl(context: UrlGenerationContext & {
+    frontmatter: FrontmatterData;
+    section: string;
+    anchor: string | null;
+  }): string | null {
+    const loio = extractLoio(context.content, context.relFile);
+    if (!loio) {
+      if (this.libraryId === '/btp-cloud-platform' && isIndexPage(context.relFile)) {
+        return `https://help.sap.com/docs/BTP/${BTP_DELIVERABLE}`;
+      }
+
+      if (this.libraryId === '/sap-artificial-intelligence') {
+        if (!context.relFile || context.relFile.startsWith('sap-ai-core/')) {
+          return `https://help.sap.com/docs/AI_CORE/${AI_CORE_DELIVERABLE}?version=CLOUD`;
+        }
+
+        if (context.relFile.startsWith('sap-ai-launchpad/')) {
+          return `https://help.sap.com/docs/AI_LAUNCHPAD/${AI_LAUNCHPAD_DELIVERABLE}?version=CLOUD`;
+        }
+      }
+
+      return null;
+    }
+
+    if (this.libraryId === '/btp-cloud-platform') {
+      return `https://help.sap.com/docs/BTP/${BTP_DELIVERABLE}/${loio}.html`;
+    }
+
+    if (this.libraryId === '/sap-artificial-intelligence') {
+      if (context.relFile.startsWith('sap-ai-core/')) {
+        return `https://help.sap.com/docs/AI_CORE/${AI_CORE_DELIVERABLE}/${loio}.html?version=CLOUD`;
+      }
+
+      if (context.relFile.startsWith('sap-ai-launchpad/')) {
+        return `https://help.sap.com/docs/AI_LAUNCHPAD/${AI_LAUNCHPAD_DELIVERABLE}/${loio}.html?version=CLOUD`;
+      }
+    }
+
+    return null;
+  }
+}

--- a/src/lib/url-generation/sapui5.ts
+++ b/src/lib/url-generation/sapui5.ts
@@ -6,6 +6,7 @@
 import { BaseUrlGenerator, UrlGenerationContext } from './BaseUrlGenerator.js';
 import { FrontmatterData } from './utils.js';
 import { DocUrlConfig } from '../metadata.js';
+import { readSourceContentSync } from '../sourceContent.js';
 
 export interface SapUi5UrlOptions {
   relFile: string;
@@ -47,14 +48,18 @@ export class SapUi5UrlGenerator extends BaseUrlGenerator {
     section: string;
     anchor: string | null;
   }): string | null {
+    if (/^(?:index|README)\.md$/i.test(context.relFile)) {
+      return this.extractFirstLinkedTopicUrl(context) || this.config.baseUrl;
+    }
+
     // SAPUI5 docs often have topic IDs in frontmatter
     const topicId = context.frontmatter.id || context.frontmatter.topic;
     if (topicId) {
       return `${this.config.baseUrl}/#/topic/${topicId}`;
     }
 
-    // SAPUI5 docs also use HTML comments with loio pattern: <!-- loio{id} -->
-    const loioMatch = context.content?.match(/<!--\s*loio([a-f0-9]+)\s*-->/);
+    // SAPUI5 docs use loio/copy HTML comments for topic identifiers.
+    const loioMatch = context.content?.match(/<!--\s*(?:loio|copy)([a-f0-9]{32})\s*-->/i);
     if (loioMatch) {
       return `${this.config.baseUrl}/#/topic/${loioMatch[1]}`;
     }
@@ -65,7 +70,33 @@ export class SapUi5UrlGenerator extends BaseUrlGenerator {
       return `${this.config.baseUrl}/#/topic/${topicIdMatch[1]}`;
     }
     
-    return null; // Let fallback handle it
+    return this.config.baseUrl;
+  }
+
+  private extractFirstLinkedTopicUrl(context: UrlGenerationContext & {
+    frontmatter: FrontmatterData;
+    section: string;
+    anchor: string | null;
+  }): string | null {
+    const linkMatch = context.content.match(/\[[^\]]+\]\(([^)#?]+\.md)(?:#[^)]+)?\)/i);
+    if (!linkMatch) {
+      return null;
+    }
+
+    const linkedRelFile = linkMatch[1].replace(/^\.\//, '');
+    const linkedContent = readSourceContentSync(this.libraryId, linkedRelFile);
+    if (!linkedContent) {
+      return null;
+    }
+
+    const linkedFrontmatter = this.parseFrontmatter(linkedContent);
+    const linkedTopicId = linkedFrontmatter.id || linkedFrontmatter.topic;
+    if (linkedTopicId) {
+      return `${this.config.baseUrl}/#/topic/${linkedTopicId}`;
+    }
+
+    const loioMatch = linkedContent.match(/<!--\s*(?:loio|copy)([a-f0-9]{32})\s*-->/i);
+    return loioMatch ? `${this.config.baseUrl}/#/topic/${loioMatch[1]}` : null;
   }
   
   /**
@@ -78,7 +109,7 @@ export class SapUi5UrlGenerator extends BaseUrlGenerator {
     anchor: string | null;
   }): string | null {
     // Extract control name from file path (e.g., src/sap/m/Button.js -> sap.m.Button)
-    const pathMatch = context.relFile.match(/src\/(sap\/[^\/]+\/[^\/]+)\.js$/);
+    const pathMatch = context.relFile.match(/(?:^|\/)src\/(sap\/.+)\.js$/);
     if (pathMatch) {
       const controlPath = pathMatch[1].replace(/\//g, '.');
       return `${this.config.baseUrl}/#/api/${controlPath}`;
@@ -116,23 +147,147 @@ export class SapUi5UrlGenerator extends BaseUrlGenerator {
     section: string;
     anchor: string | null;
   }): string | null {
-    // Extract sample ID from path patterns like:
-    // /src/sap.m/test/sap/m/demokit/sample/ButtonWithBadge/Component.js
-    const sampleMatch = context.relFile.match(/sample\/([^\/]+)\/([^\/]+)$/);
-    if (sampleMatch) {
-      const [, sampleName, fileName] = sampleMatch;
-      // For samples, we construct the sample entity URL without # prefix
-      return `${this.config.baseUrl}/entity/sap.m.Button/sample/sap.m.sample.${sampleName}`;
-    }
-    
-    // Alternative pattern for samples
-    const buttonSampleMatch = context.relFile.match(/\/([^\/]+)\/test\/sap\/m\/demokit\/sample\/([^\/]+)\//);
-    if (buttonSampleMatch) {
-      const [, controlLibrary, sampleName] = buttonSampleMatch;
-      return `${this.config.baseUrl}/entity/sap.${controlLibrary}.Button/sample/sap.${controlLibrary}.sample.${sampleName}`;
+    const sampleInfo = this.extractOpenUi5SampleInfo(context.relFile, context.content);
+    if (sampleInfo) {
+      return `${this.config.baseUrl}/#/entity/${sampleInfo.entityId}/sample/${sampleInfo.sampleId}`;
     }
     
     return null; // Let fallback handle it
+  }
+
+  private extractOpenUi5SampleInfo(relFile: string, content: string): { sampleId: string; entityId: string } | null {
+    const sampleMatch = relFile.match(/^(sap\.[^/]+)\/test\/(sap(?:\/[^/]+)+)\/demokit\/sample\/(.+)$/);
+    if (!sampleMatch) {
+      return null;
+    }
+
+    const [, , namespacePath, sampleRelativePath] = sampleMatch;
+    const namespace = namespacePath.replace(/\//g, '.');
+    const pathParts = sampleRelativePath.split('/').filter(Boolean);
+    if (pathParts.length < 2) {
+      return null;
+    }
+
+    const sampleRoot = pathParts[0];
+    const sampleRootPrefix = relFile.slice(0, relFile.length - sampleRelativePath.length);
+    const manifestRelFile = `${sampleRootPrefix}${sampleRoot}/manifest.json`;
+    const manifestContent = relFile.endsWith('/manifest.json')
+      ? content
+      : readSourceContentSync(this.libraryId, manifestRelFile);
+    const sampleId = this.extractSampleIdFromContent(manifestContent || content) || `${namespace}.sample.${sampleRoot}`;
+    const sampleRouteName = sampleId.split('.sample.')[1]?.split('.')[0] || sampleRoot;
+    const entityId = this.inferSampleEntity(namespace, sampleRouteName);
+
+    return { sampleId, entityId };
+  }
+
+  private extractSampleIdFromContent(content: string): string | null {
+    const manifestMatch = content.match(/"id"\s*:\s*"(sap\.[^"]+\.sample\.[^"]+)"/);
+    if (manifestMatch) {
+      return manifestMatch[1];
+    }
+
+    const componentMatch = content.match(/\.extend\(\s*["'](sap\.[^"']+\.sample\.[^"']+)\.Component["']/);
+    if (componentMatch) {
+      return componentMatch[1];
+    }
+
+    return null;
+  }
+
+  private inferSampleEntity(namespace: string, sampleName: string): string {
+    if (namespace === 'sap.ui.table') {
+      return sampleName.startsWith('TreeTable') ? 'sap.ui.table.TreeTable' : 'sap.ui.table.Table';
+    }
+
+    if (namespace === 'sap.uxap') {
+      if (sampleName.startsWith('AnchorBar')) {
+        return 'sap.uxap.AnchorBar';
+      }
+      if (sampleName.startsWith('ObjectPage')) {
+        return 'sap.uxap.ObjectPageLayout';
+      }
+    }
+
+    if (namespace === 'sap.f') {
+      return `${namespace}.${this.firstKnownPrefix(sampleName, [
+        'FlexibleColumnLayout',
+        'DynamicPage',
+        'SidePanel',
+        'AvatarGroup',
+        'Avatar',
+        'Card'
+      ])}`;
+    }
+
+    if (namespace === 'sap.ui.layout') {
+      return `${namespace}.${this.firstKnownPrefix(sampleName, [
+        'SimpleForm',
+        'ResponsiveGridLayout',
+        'GridData',
+        'Grid',
+        'Splitter',
+        'Form',
+        'VerticalLayout',
+        'HorizontalLayout',
+        'FixFlex'
+      ])}`;
+    }
+
+    if (namespace === 'sap.ui.unified') {
+      return `${namespace}.${this.firstKnownPrefix(sampleName, [
+        'ColorPicker',
+        'FileUploader',
+        'Calendar',
+        'Currency',
+        'Menu'
+      ])}`;
+    }
+
+    return `${namespace}.${this.firstKnownPrefix(sampleName, [
+      'ActionSheet',
+      'Breadcrumbs',
+      'Button',
+      'ComboBox',
+      'DatePicker',
+      'Dialog',
+      'FeedInput',
+      'IconTabBar',
+      'Input',
+      'Label',
+      'Link',
+      'ListBase',
+      'List',
+      'MessagePopover',
+      'MessageStrip',
+      'MessageToast',
+      'MultiComboBox',
+      'ObjectHeader',
+      'Panel',
+      'Popover',
+      'ProgressIndicator',
+      'RadioButton',
+      'RangeSlider',
+      'RatingIndicator',
+      'SearchField',
+      'SegmentedButton',
+      'Select',
+      'Slider',
+      'SplitApp',
+      'StandardListItem',
+      'Table',
+      'Text',
+      'Toolbar',
+      'UploadCollection',
+      'ViewSettingsDialog',
+      'Wizard'
+    ])}`;
+  }
+
+  private firstKnownPrefix(value: string, knownPrefixes: string[]): string {
+    return [...knownPrefixes]
+      .sort((a, b) => b.length - a.length)
+      .find(prefix => value.startsWith(prefix)) || value;
   }
 }
 
@@ -169,4 +324,3 @@ export function generateUi5UrlForLibrary(options: SapUi5UrlOptions): string | nu
   const generator = new SapUi5UrlGenerator(options.libraryId, options.config);
   return generator.generateUrl(options);
 }
-

--- a/src/lib/url-generation/sapui5.ts
+++ b/src/lib/url-generation/sapui5.ts
@@ -15,6 +15,8 @@ export interface SapUi5UrlOptions {
   libraryId: string;
 }
 
+const OPENUI5_SAMPLE_ENTITY_CACHE = new Map<string, Map<string, string>>();
+
 /**
  * SAPUI5 URL Generator
  * Handles SAPUI5 guides, OpenUI5 API docs, and samples with different URL patterns
@@ -175,8 +177,7 @@ export class SapUi5UrlGenerator extends BaseUrlGenerator {
       ? content
       : readSourceContentSync(this.libraryId, manifestRelFile);
     const sampleId = this.extractSampleIdFromContent(manifestContent || content) || `${namespace}.sample.${sampleRoot}`;
-    const sampleRouteName = sampleId.split('.sample.')[1]?.split('.')[0] || sampleRoot;
-    const entityId = this.inferSampleEntity(namespace, sampleRouteName);
+    const entityId = this.findOpenUi5SampleEntity(relFile, sampleId) || this.fallbackOpenUi5SampleEntity(namespace, sampleId, sampleRoot);
 
     return { sampleId, entityId };
   }
@@ -195,99 +196,67 @@ export class SapUi5UrlGenerator extends BaseUrlGenerator {
     return null;
   }
 
-  private inferSampleEntity(namespace: string, sampleName: string): string {
-    if (namespace === 'sap.ui.table') {
-      return sampleName.startsWith('TreeTable') ? 'sap.ui.table.TreeTable' : 'sap.ui.table.Table';
+  private findOpenUi5SampleEntity(relFile: string, sampleId: string): string | null {
+    const docuIndexRelFile = this.getOpenUi5DocuIndexRelFile(relFile);
+    if (!docuIndexRelFile) {
+      return null;
     }
 
-    if (namespace === 'sap.uxap') {
-      if (sampleName.startsWith('AnchorBar')) {
-        return 'sap.uxap.AnchorBar';
-      }
-      if (sampleName.startsWith('ObjectPage')) {
-        return 'sap.uxap.ObjectPageLayout';
-      }
-    }
-
-    if (namespace === 'sap.f') {
-      return `${namespace}.${this.firstKnownPrefix(sampleName, [
-        'FlexibleColumnLayout',
-        'DynamicPage',
-        'SidePanel',
-        'AvatarGroup',
-        'Avatar',
-        'Card'
-      ])}`;
-    }
-
-    if (namespace === 'sap.ui.layout') {
-      return `${namespace}.${this.firstKnownPrefix(sampleName, [
-        'SimpleForm',
-        'ResponsiveGridLayout',
-        'GridData',
-        'Grid',
-        'Splitter',
-        'Form',
-        'VerticalLayout',
-        'HorizontalLayout',
-        'FixFlex'
-      ])}`;
-    }
-
-    if (namespace === 'sap.ui.unified') {
-      return `${namespace}.${this.firstKnownPrefix(sampleName, [
-        'ColorPicker',
-        'FileUploader',
-        'Calendar',
-        'Currency',
-        'Menu'
-      ])}`;
-    }
-
-    return `${namespace}.${this.firstKnownPrefix(sampleName, [
-      'ActionSheet',
-      'Breadcrumbs',
-      'Button',
-      'ComboBox',
-      'DatePicker',
-      'Dialog',
-      'FeedInput',
-      'IconTabBar',
-      'Input',
-      'Label',
-      'Link',
-      'ListBase',
-      'List',
-      'MessagePopover',
-      'MessageStrip',
-      'MessageToast',
-      'MultiComboBox',
-      'ObjectHeader',
-      'Panel',
-      'Popover',
-      'ProgressIndicator',
-      'RadioButton',
-      'RangeSlider',
-      'RatingIndicator',
-      'SearchField',
-      'SegmentedButton',
-      'Select',
-      'Slider',
-      'SplitApp',
-      'StandardListItem',
-      'Table',
-      'Text',
-      'Toolbar',
-      'UploadCollection',
-      'ViewSettingsDialog',
-      'Wizard'
-    ])}`;
+    const sampleEntityMap = this.getOpenUi5SampleEntityMap(docuIndexRelFile);
+    return sampleEntityMap.get(sampleId) || null;
   }
 
-  private firstKnownPrefix(value: string, knownPrefixes: string[]): string {
-    return [...knownPrefixes]
-      .sort((a, b) => b.length - a.length)
-      .find(prefix => value.startsWith(prefix)) || value;
+  private getOpenUi5DocuIndexRelFile(relFile: string): string | null {
+    const sampleMatch = relFile.match(/^(sap\.[^/]+)\/test\/(sap(?:\/[^/]+)+)\/demokit\/sample\//);
+    if (!sampleMatch) {
+      return null;
+    }
+
+    const [, libraryFolder, namespacePath] = sampleMatch;
+    return `${libraryFolder}/test/${namespacePath}/demokit/docuindex.json`;
+  }
+
+  private getOpenUi5SampleEntityMap(docuIndexRelFile: string): Map<string, string> {
+    const cacheKey = `${this.libraryId}:${docuIndexRelFile}`;
+    const cached = OPENUI5_SAMPLE_ENTITY_CACHE.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
+
+    const sampleEntityMap = new Map<string, string>();
+    const docuIndexContent = readSourceContentSync(this.libraryId, docuIndexRelFile);
+    if (!docuIndexContent) {
+      OPENUI5_SAMPLE_ENTITY_CACHE.set(cacheKey, sampleEntityMap);
+      return sampleEntityMap;
+    }
+
+    try {
+      const docuIndex = JSON.parse(docuIndexContent);
+      const entities = docuIndex?.explored?.entities;
+      if (Array.isArray(entities)) {
+        for (const entity of entities) {
+          if (typeof entity?.id !== 'string' || !Array.isArray(entity.samples)) {
+            continue;
+          }
+
+          for (const sampleId of entity.samples) {
+            if (typeof sampleId === 'string') {
+              sampleEntityMap.set(sampleId, entity.id);
+            }
+          }
+        }
+      }
+    } catch {
+      // Ignore malformed local metadata and use the generic fallback.
+    }
+
+    OPENUI5_SAMPLE_ENTITY_CACHE.set(cacheKey, sampleEntityMap);
+    return sampleEntityMap;
+  }
+
+  private fallbackOpenUi5SampleEntity(namespace: string, sampleId: string, sampleRoot: string): string {
+    const sampleRouteName = sampleId.split('.sample.')[1]?.split('.')[0] || sampleRoot;
+    return `${namespace}.${sampleRouteName}`;
   }
 }
 

--- a/src/lib/url-generation/terraform-btp.ts
+++ b/src/lib/url-generation/terraform-btp.ts
@@ -12,13 +12,8 @@ export class TerraformBtpUrlGenerator extends BaseUrlGenerator {
     section: string;
     anchor: string | null;
   }): string | null {
-    const relPath = context.relFile.replace(/\.mdx?$/, '');
-    let url = this.config.baseUrl + this.config.pathPattern.replace('{file}', relPath);
-
-    if (context.anchor) {
-      url += this.getSeparator() + context.anchor;
-    }
-
-    return url;
+    const relPath = context.relFile.replace(/^docs\//, '').replace(/\.md$/, '');
+    const registryPath = relPath === 'index' ? '' : relPath;
+    return this.buildUrl(this.config.baseUrl, registryPath);
   }
 }

--- a/src/lib/url-generation/ui5-typescript.ts
+++ b/src/lib/url-generation/ui5-typescript.ts
@@ -1,0 +1,26 @@
+import { BaseUrlGenerator, UrlGenerationContext } from './BaseUrlGenerator.js';
+import { FrontmatterData } from './utils.js';
+
+function toHtmlPath(relFile: string): string {
+  if (/^README\.md$/i.test(relFile) || /^index\.md$/i.test(relFile)) {
+    return '';
+  }
+
+  return relFile.replace(/\.md$/i, '.html');
+}
+
+export class Ui5TypeScriptUrlGenerator extends BaseUrlGenerator {
+  protected generateSourceSpecificUrl(context: UrlGenerationContext & {
+    frontmatter: FrontmatterData;
+    section: string;
+    anchor: string | null;
+  }): string | null {
+    let url = this.buildUrl(this.config.baseUrl, toHtmlPath(context.relFile));
+
+    if (context.anchor) {
+      url += `#${context.anchor}`;
+    }
+
+    return url;
+  }
+}

--- a/src/lib/url-generation/ui5-webcomponents.ts
+++ b/src/lib/url-generation/ui5-webcomponents.ts
@@ -1,0 +1,14 @@
+import { BaseUrlGenerator, UrlGenerationContext } from './BaseUrlGenerator.js';
+import { buildDocusaurusPath } from './docusaurus.js';
+import { FrontmatterData } from './utils.js';
+
+export class Ui5WebComponentsUrlGenerator extends BaseUrlGenerator {
+  protected generateSourceSpecificUrl(context: UrlGenerationContext & {
+    frontmatter: FrontmatterData;
+    section: string;
+    anchor: string | null;
+  }): string | null {
+    const route = buildDocusaurusPath(context.relFile, context.frontmatter);
+    return this.buildUrl(this.config.baseUrl, 'docs', route) + '/';
+  }
+}

--- a/src/lib/url-generation/utils.ts
+++ b/src/lib/url-generation/utils.ts
@@ -2,6 +2,9 @@
  * Common utilities for URL generation across different documentation sources
  */
 
+import { readSourceContentSync } from '../sourceContent.js';
+import matter from 'gray-matter';
+
 export interface FrontmatterData {
   id?: string;
   slug?: string;
@@ -15,63 +18,34 @@ export interface FrontmatterData {
  * Supports YAML frontmatter format used in Markdown/MDX files
  */
 export function parseFrontmatter(content: string): FrontmatterData {
-  const frontmatterMatch = content.match(/^---\s*\n([\s\S]*?)\n---/);
-  if (!frontmatterMatch) {
+  try {
+    return matter(content).data as FrontmatterData;
+  } catch {
     return {};
   }
-
-  const frontmatter = frontmatterMatch[1];
-  const result: FrontmatterData = {};
-
-  // Parse simple key-value pairs
-  const lines = frontmatter.split('\n');
-  let currentKey = '';
-  let isInArray = false;
-  
-  for (const line of lines) {
-    const trimmedLine = line.trim();
-    
-    if (!trimmedLine || trimmedLine.startsWith('#')) {
-      continue; // Skip empty lines and comments
-    }
-    
-    // Handle array items (lines starting with -)
-    if (trimmedLine.startsWith('-')) {
-      if (isInArray && currentKey) {
-        const arrayValue = trimmedLine.substring(1).trim();
-        if (!Array.isArray(result[currentKey])) {
-          result[currentKey] = [];
-        }
-        (result[currentKey] as string[]).push(arrayValue);
-      }
-      continue;
-    }
-    
-    // Handle key-value pairs
-    const colonIndex = trimmedLine.indexOf(':');
-    if (colonIndex !== -1) {
-      currentKey = trimmedLine.substring(0, colonIndex).trim();
-      const value = trimmedLine.substring(colonIndex + 1).trim();
-      
-      if (value === '') {
-        // This might be the start of an array
-        isInArray = true;
-        result[currentKey] = [];
-      } else {
-        isInArray = false;
-        // Clean up quoted values
-        result[currentKey] = value.replace(/^["']|["']$/g, '');
-      }
-    }
-  }
-
-  return result;
 }
 
 /**
  * Detect the main section/topic from content for anchor generation
  */
-export function detectContentSection(content: string, anchorStyle: 'docsify' | 'github' | 'custom'): string | null {
+export type AnchorStyle = 'docsify' | 'github' | 'custom' | 'sap-help';
+
+function slugifyMarkdownHeading(heading: string, collapseHyphens = false): string {
+  let slug = heading
+    .trim()
+    .toLowerCase()
+    .replace(/[^\p{Letter}\p{Number}_\s-]/gu, '')
+    .replace(/\s+/g, '-')
+    .replace(/^-|-$/g, '');
+
+  if (collapseHyphens) {
+    slug = slug.replace(/-+/g, '-');
+  }
+
+  return slug;
+}
+
+export function detectContentSection(content: string, anchorStyle: AnchorStyle): string | null {
   // Find the first major heading (## or #) that gives context about the content
   const headingMatch = content.match(/^#{1,2}\s+(.+)$/m);
   if (!headingMatch) {
@@ -83,25 +57,16 @@ export function detectContentSection(content: string, anchorStyle: 'docsify' | '
   // Convert heading to anchor format based on style
   switch (anchorStyle) {
     case 'docsify':
-      // Docsify format: lowercase, spaces to hyphens, remove special chars
-      return heading
-        .toLowerCase()
-        .replace(/[^\w\s-]/g, '') // Remove special characters except hyphens
-        .replace(/\s+/g, '-')     // Spaces to hyphens
-        .replace(/-+/g, '-')      // Multiple hyphens to single
-        .replace(/^-|-$/g, '');   // Remove leading/trailing hyphens
+      return slugifyMarkdownHeading(heading, true);
         
     case 'github':
-      // GitHub format: lowercase, spaces to hyphens, keep some special chars
-      return heading
-        .toLowerCase()
-        .replace(/[^\w\s-]/g, '')
-        .replace(/\s+/g, '-');
+      return slugifyMarkdownHeading(heading);
         
     case 'custom':
+    case 'sap-help':
     default:
       // Return as-is for custom handling
-      return heading;
+      return anchorStyle === 'sap-help' ? null : heading;
   }
 }
 
@@ -192,7 +157,7 @@ export function formatSearchResult(
 ): string {
   // Extract library ID and relative file path to generate URL
   const libraryId = result.sourceId ? `/${result.sourceId}` : extractLibraryIdFromPath(result.id);
-  const relFile = extractRelativeFileFromPath(result.id);
+  const relFile = result.relFile || extractRelativeFileFromPath(result.id);
   
   // Try to generate documentation URL
   let urlInfo = '';
@@ -200,7 +165,8 @@ export function formatSearchResult(
     try {
       const config = urlGenerator.getDocUrlConfig && urlGenerator.getDocUrlConfig(libraryId);
       if (config && urlGenerator.generateDocumentationUrl) {
-        const docUrl = urlGenerator.generateDocumentationUrl(libraryId, relFile, result.text || '', config);
+        const sourceContent = readSourceContentSync(libraryId, relFile);
+        const docUrl = urlGenerator.generateDocumentationUrl(libraryId, relFile, sourceContent || result.text || '', config);
         if (docUrl) {
           urlInfo = `\n   🔗 ${docUrl}`;
         }
@@ -213,4 +179,3 @@ export function formatSearchResult(
   
   return `⭐️ **${result.id}** (Score: ${result.finalScore.toFixed(2)})\n   ${(result.text || '').substring(0, excerptLength)}${urlInfo}\n   Use in fetch\n`;
 }
-

--- a/src/lib/url-generation/wdi5.ts
+++ b/src/lib/url-generation/wdi5.ts
@@ -25,6 +25,10 @@ export class Wdi5UrlGenerator extends BaseUrlGenerator {
     section: string;
     anchor: string | null;
   }): string | null {
+    if (/^(?:README|index)\.md$/i.test(context.relFile)) {
+      return `${this.config.baseUrl}/#/`;
+    }
+
     const identifier = this.getIdentifierFromFrontmatter(context.frontmatter);
     
     // Use frontmatter id for docsify-style URLs
@@ -109,4 +113,3 @@ export function generateWdi5ConfigUrl(options: Wdi5UrlOptions): string | null {
 export function generateWdi5SelectorUrl(options: Wdi5UrlOptions): string | null {
   return generateWdi5Url(options); // Now handled by the main generator
 }
-

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -53,7 +53,7 @@
       "libraryId": "/openui5-samples",
       "sourcePath": "openui5/src",
       "baseUrl": "https://sdk.openui5.org",
-      "pathPattern": "/entity/{file}",
+      "pathPattern": "/#/entity/{file}",
       "anchorStyle": "custom"
     },
     {
@@ -78,7 +78,7 @@
       "description": "UI5 Tooling documentation",
       "libraryId": "/ui5-tooling",
       "sourcePath": "ui5-tooling/docs",
-      "baseUrl": "https://sap.github.io/ui5-tooling/v4",
+      "baseUrl": "https://ui5.github.io/cli/v4",
       "pathPattern": "/pages/{file}",
       "anchorStyle": "github"
     },
@@ -104,8 +104,8 @@
       "description": "UI5 Web Components",
       "libraryId": "/ui5-webcomponents",
       "sourcePath": "ui5-webcomponents/docs",
-      "baseUrl": "https://sap.github.io/ui5-webcomponents/docs",
-      "pathPattern": "/{file}",
+      "baseUrl": "https://ui5.github.io/webcomponents",
+      "pathPattern": "/docs/{file}/",
       "anchorStyle": "github"
     },
     {
@@ -169,8 +169,8 @@
       "description": "UI5 TypeScript",
       "libraryId": "/ui5-typescript",
       "sourcePath": "ui5-typescript",
-      "baseUrl": "https://github.com/UI5/typescript/blob/gh-pages",
-      "pathPattern": "/{file}",
+      "baseUrl": "https://ui5.github.io/typescript",
+      "pathPattern": "/{file}.html",
       "anchorStyle": "github"
     },
     {
@@ -252,6 +252,45 @@
       "anchorStyle": "github"
     },
     {
+      "id": "abap-platform-rap-opensap",
+      "type": "samples",
+      "lang": "en",
+      "boost": 0.07,
+      "tags": ["rap", "abap", "samples", "opensap", "course", "tutorial"],
+      "description": "RAP openSAP Course Samples - Building Apps with ABAP RESTful Application Programming",
+      "libraryId": "/abap-platform-rap-opensap",
+      "sourcePath": "abap-platform-rap-opensap",
+      "baseUrl": "https://github.com/SAP-samples/abap-platform-rap-opensap/blob/main",
+      "pathPattern": "/{file}",
+      "anchorStyle": "github"
+    },
+    {
+      "id": "cloud-abap-rap",
+      "type": "samples",
+      "lang": "en",
+      "boost": 0.07,
+      "tags": ["rap", "abap", "cloud", "btp", "samples", "examples"],
+      "description": "ABAP Cloud + RAP Examples - RAP development in ABAP Cloud environment",
+      "libraryId": "/cloud-abap-rap",
+      "sourcePath": "cloud-abap-rap",
+      "baseUrl": "https://github.com/SAP-samples/cloud-abap-rap/blob/main",
+      "pathPattern": "/{file}",
+      "anchorStyle": "github"
+    },
+    {
+      "id": "abap-platform-reuse-services",
+      "type": "samples",
+      "lang": "en",
+      "boost": 0.06,
+      "tags": ["rap", "abap", "reuse", "services", "number-range", "change-documents"],
+      "description": "RAP Reuse Services - Number Ranges, Change Documents, Mail, Adobe Forms",
+      "libraryId": "/abap-platform-reuse-services",
+      "sourcePath": "abap-platform-reuse-services",
+      "baseUrl": "https://github.com/SAP-samples/abap-platform-reuse-services/blob/main",
+      "pathPattern": "/{file}",
+      "anchorStyle": "github"
+    },
+    {
       "id": "abap-docs-standard",
       "type": "documentation",
       "lang": "en",
@@ -286,9 +325,9 @@
       "description": "SAP Business Technology Platform documentation",
       "libraryId": "/btp-cloud-platform",
       "sourcePath": "btp-cloud-platform/docs",
-      "baseUrl": "https://github.com/SAP-docs/btp-cloud-platform/blob/main",
-      "pathPattern": "/docs/{file}",
-      "anchorStyle": "github"
+      "baseUrl": "https://help.sap.com/docs/BTP/65de2977205c403bbc107264b8eccf4b",
+      "pathPattern": "/{file}.html",
+      "anchorStyle": "sap-help"
     },
     {
       "id": "sap-artificial-intelligence",
@@ -299,9 +338,9 @@
       "description": "SAP AI Core and SAP AI Launchpad documentation",
       "libraryId": "/sap-artificial-intelligence",
       "sourcePath": "sap-artificial-intelligence/docs",
-      "baseUrl": "https://github.com/SAP-docs/sap-artificial-intelligence/blob/main",
-      "pathPattern": "/docs/{file}",
-      "anchorStyle": "github"
+      "baseUrl": "https://help.sap.com/docs",
+      "pathPattern": "/{file}.html",
+      "anchorStyle": "sap-help"
     },
     {
       "id": "terraform-provider-btp",
@@ -312,9 +351,9 @@
       "description": "Terraform provider documentation for SAP BTP",
       "libraryId": "/terraform-provider-btp",
       "sourcePath": "terraform-provider-btp",
-      "baseUrl": "https://github.com/SAP/terraform-provider-btp/blob/main",
+      "baseUrl": "https://registry.terraform.io/providers/SAP/btp/latest/docs",
       "pathPattern": "/{file}",
-      "anchorStyle": "github"
+      "anchorStyle": "custom"
     },
     {
       "id": "architecture-center",
@@ -536,6 +575,9 @@
     "dsag-abap-leitfaden": "dsag-abap-leitfaden",
     "abap-fiori-showcase": "abap-fiori-showcase",
     "cap-fiori-showcase": "cap-fiori-showcase",
+    "abap-platform-rap-opensap": "abap-platform-rap-opensap",
+    "cloud-abap-rap": "cloud-abap-rap",
+    "abap-platform-reuse-services": "abap-platform-reuse-services",
     "teched2025-dt260": "teched2025-dt260",
     "abap-docs-standard": "abap-docs",
     "abap-docs-cloud": "abap-docs",

--- a/test/comprehensive-url-generation.test.ts
+++ b/test/comprehensive-url-generation.test.ts
@@ -31,11 +31,16 @@ import {
   CapUrlGenerator,
   Wdi5UrlGenerator,
   DsagUrlGenerator,
-  GenericUrlGenerator,
-  ArchitectureCenterUrlGenerator
+  ArchitectureCenterUrlGenerator,
+  GithubBlobUrlGenerator,
+  MkDocsUrlGenerator,
+  SapHelpLoioUrlGenerator,
+  Ui5TypeScriptUrlGenerator,
+  Ui5WebComponentsUrlGenerator
 } from '../src/lib/url-generation/index.js';
 import { AbapUrlGenerator, generateAbapUrl } from '../src/lib/url-generation/abap.js';
 import { DocUrlConfig, getDocUrlConfig } from '../src/lib/metadata.js';
+import { normalizeCommunityUrl } from '../src/lib/communityBestMatch.js';
 
 describe('Comprehensive URL Generation System', () => {
   
@@ -135,26 +140,26 @@ describe('Comprehensive URL Generation System', () => {
    * - libraryId: Library identifier from metadata.json
    * - relFile: Relative file path within the library (used for path mapping)
    * - expectedUrl: Expected generated URL for validation
-   * - frontmatter: Fallback YAML frontmatter (used when real file not found)
-   * - content: Fallback content (used when real file not found)
+   * - frontmatter: YAML frontmatter fixture
+   * - content: Markdown or MDX fixture content
    * 
-   * The system will attempt to read real source files first, falling back to
-   * the provided frontmatter/content if the file doesn't exist.
+   * The main matrix intentionally uses fixture content so URL expectations
+   * stay deterministic even when submodules are updated.
    */
   const testCases = [
     {
       name: 'CAP - CDS Log Documentation',
       libraryId: '/cap',
       relFile: 'node.js/cds-log.md',
-      expectedUrl: 'https://cap.cloud.sap/docs/#/node.js/cds-log',
+      expectedUrl: 'https://cap.cloud.sap/docs/node.js/cds-log',
       frontmatter: '---\nid: cds-log\ntitle: Logging\n---\n',
       content: '# Logging\n\nCAP provides structured logging capabilities...'
     },
     {
       name: 'Cloud MTA Build Tool - Download Page',
       libraryId: '/cloud-mta-build-tool',
-      relFile: 'docs/download.md',
-      expectedUrl: 'https://sap.github.io/cloud-mta-build-tool/download',
+      relFile: 'download.md',
+      expectedUrl: 'https://sap.github.io/cloud-mta-build-tool/download/',
       frontmatter: '',
       content: '\nYou can install the Cloud MTA Build Tool...'
     },
@@ -185,24 +190,24 @@ describe('Comprehensive URL Generation System', () => {
     {
       name: 'OpenUI5 Samples - ButtonWithBadge',
       libraryId: '/openui5-samples',
-      relFile: 'src/sap.m/test/sap/m/demokit/sample/ButtonWithBadge/Component.js',
-      expectedUrl: 'https://sdk.openui5.org/entity/sap.m.Button/sample/sap.m.sample.ButtonWithBadge',
+      relFile: 'sap.m/test/sap/m/demokit/sample/ButtonWithBadge/Component.js',
+      expectedUrl: 'https://sdk.openui5.org/#/entity/sap.m.Button/sample/sap.m.sample.ButtonWithBadge',
       frontmatter: '',
-      content: 'sap.ui.define([\n  "sap/ui/core/UIComponent"\n], function (UIComponent) {\n  // Sample implementation'
+      content: 'sap.ui.define([\n  "sap/ui/core/UIComponent"\n], function (UIComponent) {\n  var Component = UIComponent.extend("sap.m.sample.ButtonWithBadge.Component", {});'
     },
-         {
-       name: 'SAPUI5 - Multi-Selection Navigation',
-       libraryId: '/sapui5',
-       relFile: '06_SAP_Fiori_Elements/multi-selection-for-intent-based-navigation-640cabf.md',
-       expectedUrl: 'https://ui5.sap.com/#/topic/640cabfd35c3469aacf31be28924d50d',
-       frontmatter: '---\nid: 640cabfd35c3469aacf31be28924d50d\ntopic: 640cabfd35c3469aacf31be28924d50d\ntitle: Multi-Selection for Intent-Based Navigation\n---\n',
-       content: '# Multi-Selection for Intent-Based Navigation\n\nThis feature allows...'
-     },
+    {
+      name: 'SAPUI5 - Multi-Selection Navigation',
+      libraryId: '/sapui5',
+      relFile: '06_SAP_Fiori_Elements/multi-selection-for-intent-based-navigation-640cabf.md',
+      expectedUrl: 'https://ui5.sap.com/#/topic/640cabfd35c3469aacf31be28924d50d',
+      frontmatter: '---\nid: 640cabfd35c3469aacf31be28924d50d\ntopic: 640cabfd35c3469aacf31be28924d50d\ntitle: Multi-Selection for Intent-Based Navigation\n---\n',
+      content: '# Multi-Selection for Intent-Based Navigation\n\nThis feature allows...'
+    },
     {
       name: 'UI5 Tooling - Builder Documentation',
       libraryId: '/ui5-tooling',
       relFile: 'pages/Builder.md',
-      expectedUrl: 'https://sap.github.io/ui5-tooling/v4/pages/Builder#ui5-builder',
+      expectedUrl: 'https://ui5.github.io/cli/v4/pages/Builder/#ui5-builder',
       frontmatter: '',
       content: '# UI5 Builder\n\nThe UI5 Builder module takes care of building your project...'
     },
@@ -210,7 +215,7 @@ describe('Comprehensive URL Generation System', () => {
       name: 'UI5 Web Components - Configuration',
       libraryId: '/ui5-webcomponents',
       relFile: '2-advanced/01-configuration.md',
-      expectedUrl: 'https://sap.github.io/ui5-webcomponents/docs/01-configuration#configuration',
+      expectedUrl: 'https://ui5.github.io/webcomponents/docs/advanced/configuration/',
       frontmatter: '',
       content: '# Configuration\n\nThis section explains how you can configure UI5 Web Components...'
     },
@@ -226,7 +231,7 @@ describe('Comprehensive URL Generation System', () => {
       name: 'UI5 TypeScript - FAQ Documentation',
       libraryId: '/ui5-typescript',
       relFile: 'faq.md',
-      expectedUrl: 'https://github.com/UI5/typescript/blob/gh-pages/faq#faq---frequently-asked-questions-for-the-ui5-type-definitions',
+      expectedUrl: 'https://ui5.github.io/typescript/faq.html#faq---frequently-asked-questions-for-the-ui5-type-definitions',
       frontmatter: '',
       content: '# FAQ - Frequently Asked Questions for the UI5 Type Definitions\n\nWhile the [main page](README.md) answers the high-level questions...'
     },
@@ -242,7 +247,7 @@ describe('Comprehensive URL Generation System', () => {
       name: 'ABAP Cheat Sheets - Internal Tables',
       libraryId: '/abap-cheat-sheets',
       relFile: '01_Internal_Tables.md',
-      expectedUrl: 'https://github.com/SAP-samples/abap-cheat-sheets/blob/main/01_Internal_Tables#internal-tables',
+      expectedUrl: 'https://github.com/SAP-samples/abap-cheat-sheets/blob/main/01_Internal_Tables.md#internal-tables',
       frontmatter: '',
       content: '# Internal Tables\n\nThis cheat sheet contains a selection of syntax examples and notes on internal tables...'
     },
@@ -250,7 +255,7 @@ describe('Comprehensive URL Generation System', () => {
       name: 'SAP Style Guides - Clean ABAP',
       libraryId: '/sap-styleguides',
       relFile: 'clean-abap/CleanABAP.md',
-      expectedUrl: 'https://github.com/SAP/styleguides/blob/main/CleanABAP#clean-abap',
+      expectedUrl: 'https://github.com/SAP/styleguides/blob/main/clean-abap/CleanABAP.md#clean-abap',
       frontmatter: '',
       content: '# Clean ABAP\n\n> [**中文**](CleanABAP_zh.md)\n\nThis style guide presents the essentials of clean ABAP...'
     },
@@ -266,7 +271,7 @@ describe('Comprehensive URL Generation System', () => {
       name: 'ABAP Platform Fiori Feature Showcase - General Features',
       libraryId: '/abap-fiori-showcase',
       relFile: '01_general_features.md',
-      expectedUrl: 'https://github.com/SAP-samples/abap-platform-fiori-feature-showcase/blob/main/01_general_features#general-features',
+      expectedUrl: 'https://github.com/SAP-samples/abap-platform-fiori-feature-showcase/blob/main/01_general_features.md#general-features',
       frontmatter: '',
       content: '# General Features\n\nThis section describes the features that are generally used throughout...'
     },
@@ -274,15 +279,47 @@ describe('Comprehensive URL Generation System', () => {
       name: 'CAP Fiori Elements Feature Showcase - README',
       libraryId: '/cap-fiori-showcase',
       relFile: 'README.md',
-      expectedUrl: 'https://github.com/SAP-samples/fiori-elements-feature-showcase/blob/main/README#sap-fiori-elements-for-odata-v4-feature-showcase',
+      expectedUrl: 'https://github.com/SAP-samples/fiori-elements-feature-showcase/blob/main/README.md#sap-fiori-elements-for-odata-v4-feature-showcase',
       frontmatter: '',
       content: '# SAP Fiori Elements for OData V4 Feature Showcase\n\nThis app showcases different features of SAP Fiori elements...'
+    },
+    {
+      name: 'RAP openSAP Samples - README',
+      libraryId: '/abap-platform-rap-opensap',
+      relFile: 'README.md',
+      expectedUrl: 'https://github.com/SAP-samples/abap-platform-rap-opensap/blob/main/README.md#rap-opensap-course-samples',
+      frontmatter: '',
+      content: '# RAP openSAP Course Samples\n\nSample code for RAP.'
+    },
+    {
+      name: 'Cloud ABAP RAP Samples - README',
+      libraryId: '/cloud-abap-rap',
+      relFile: 'README.md',
+      expectedUrl: 'https://github.com/SAP-samples/cloud-abap-rap/blob/main/README.md#sap-cloud-abap-rap',
+      frontmatter: '',
+      content: '# SAP Cloud ABAP RAP\n\nRAP examples for ABAP Cloud.'
+    },
+    {
+      name: 'ABAP Platform Reuse Services - README',
+      libraryId: '/abap-platform-reuse-services',
+      relFile: 'README.md',
+      expectedUrl: 'https://github.com/SAP-samples/abap-platform-reuse-services/blob/main/README.md#abap-platform-reuse-services',
+      frontmatter: '',
+      content: '# ABAP Platform Reuse Services\n\nReuse service examples.'
+    },
+    {
+      name: 'TechEd 2025 DT260 - README',
+      libraryId: '/teched2025-dt260',
+      relFile: 'README.md',
+      expectedUrl: 'https://github.com/SAP-samples/teched2025-DT260/blob/main/README.md#teched-2025-dt260',
+      frontmatter: '',
+      content: '# TechEd 2025 DT260\n\nABAP clean core modernization.'
     },
     {
       name: 'Terraform BTP Provider - Index',
       libraryId: '/terraform-provider-btp',
       relFile: 'docs/index.md',
-      expectedUrl: 'https://github.com/SAP/terraform-provider-btp/blob/main/docs/index#terraform-provider-for-sap-btp',
+      expectedUrl: 'https://registry.terraform.io/providers/SAP/btp/latest/docs',
       frontmatter: '',
       content: '# Terraform Provider for SAP BTP\n\nThe Terraform provider for SAP BTP enables you...'
     },
@@ -290,7 +327,7 @@ describe('Comprehensive URL Generation System', () => {
       name: 'Terraform BTP Data Source - Subaccount',
       libraryId: '/terraform-provider-btp',
       relFile: 'docs/data-sources/subaccount.md',
-      expectedUrl: 'https://github.com/SAP/terraform-provider-btp/blob/main/docs/data-sources/subaccount#btp_subaccount-data-source',
+      expectedUrl: 'https://registry.terraform.io/providers/SAP/btp/latest/docs/data-sources/subaccount',
       frontmatter: '',
       content: '# btp_subaccount (Data Source)\n\nGets details about a subaccount.'
     },
@@ -298,7 +335,7 @@ describe('Comprehensive URL Generation System', () => {
       name: 'Terraform BTP Function - Extract CF API URL',
       libraryId: '/terraform-provider-btp',
       relFile: 'docs/functions/extract_cf_api_url.md',
-      expectedUrl: 'https://github.com/SAP/terraform-provider-btp/blob/main/docs/functions/extract_cf_api_url#extract_cf_api_url-function',
+      expectedUrl: 'https://registry.terraform.io/providers/SAP/btp/latest/docs/functions/extract_cf_api_url',
       frontmatter: '',
       content: '# extract_cf_api_url (function)\n\nParses the label string...'
     },
@@ -306,7 +343,7 @@ describe('Comprehensive URL Generation System', () => {
       name: 'Terraform BTP List Resource - Subaccount',
       libraryId: '/terraform-provider-btp',
       relFile: 'docs/list-resources/subaccount.md',
-      expectedUrl: 'https://github.com/SAP/terraform-provider-btp/blob/main/docs/list-resources/subaccount#btp_subaccount-list-resource',
+      expectedUrl: 'https://registry.terraform.io/providers/SAP/btp/latest/docs/list-resources/subaccount',
       frontmatter: '',
       content: '# btp_subaccount (List Resource)\n\nThis list resource allows you to discover all subaccounts.'
     },
@@ -314,9 +351,33 @@ describe('Comprehensive URL Generation System', () => {
       name: 'Terraform BTP Resource - Subaccount',
       libraryId: '/terraform-provider-btp',
       relFile: 'docs/resources/subaccount.md',
-      expectedUrl: 'https://github.com/SAP/terraform-provider-btp/blob/main/docs/resources/subaccount#btp_subaccount-resource',
+      expectedUrl: 'https://registry.terraform.io/providers/SAP/btp/latest/docs/resources/subaccount',
       frontmatter: '',
       content: '# btp_subaccount (Resource)\n\nCreates a subaccount in a global account or directory.'
+    },
+    {
+      name: 'SAP Help BTP - LOIO URL',
+      libraryId: '/btp-cloud-platform',
+      relFile: '20-getting-started/abap-environment-initial-settings-a999fac.md',
+      expectedUrl: 'https://help.sap.com/docs/BTP/65de2977205c403bbc107264b8eccf4b/a999fac2a578468ea0e4e320c82145ce.html',
+      frontmatter: '',
+      content: '<!-- loioa999fac2a578468ea0e4e320c82145ce -->\n\n# ABAP Environment Initial Settings'
+    },
+    {
+      name: 'SAP Help AI Core - LOIO URL',
+      libraryId: '/sap-artificial-intelligence',
+      relFile: 'sap-ai-core/delete-a-docker-registry-secret-5ff30f0.md',
+      expectedUrl: 'https://help.sap.com/docs/AI_CORE/2d6c5984063c40a59eda62f4a9135bee/5ff30f0332b8452d97ed77edf746714a.html?version=CLOUD',
+      frontmatter: '',
+      content: '<!-- loio5ff30f0332b8452d97ed77edf746714a -->\n\n# Delete a Docker Registry Secret'
+    },
+    {
+      name: 'SAP Help AI Launchpad - LOIO URL',
+      libraryId: '/sap-artificial-intelligence',
+      relFile: 'sap-ai-launchpad/using-sap-ai-launchpad-bbc7e21.md',
+      expectedUrl: 'https://help.sap.com/docs/AI_LAUNCHPAD/92d77f26188e4582897b9106b9cb72e0/bbc7e21629ce4aef87d85c30cc8b1be8.html?version=CLOUD',
+      frontmatter: '',
+      content: '<!-- loiobbc7e21629ce4aef87d85c30cc8b1be8 -->\n\n# Using SAP AI Launchpad'
     },
     // Architecture Center - slug-based URL generation
     {
@@ -335,8 +396,6 @@ describe('Comprehensive URL Generation System', () => {
       frontmatter: '---\nid: id-ra0005\nslug: /ref-arch/e5eb3b9b1d\ntitle: Generative AI on SAP BTP\ndescription: Integrate Generative AI with SAP BTP using SAP HANA Cloud Vector Engine.\nkeywords:\n  - generative ai hub\n  - vector engine integration\n---\n',
       content: '# Generative AI on SAP BTP\n\nIntegrate Generative AI with SAP BTP...'
     }
-    // Note: Some sources like CAP, Cloud SDK AI, wdi5, etc. may need different file mappings
-    // or fallback to mock content if actual files don't exist in expected locations
   ];
 
   describe('Main URL Generation Function', () => {
@@ -345,19 +404,12 @@ describe('Comprehensive URL Generation System', () => {
         // Step 1: Get configuration from metadata.json
         const config = getConfigForLibrary(libraryId);
         
-        // Step 2: Try to read from actual source file first, fallback to test data
-        let fileContent = readFileContent(libraryId, relFile);
-        let contentSource = 'real file';
-        
-        if (!fileContent) {
-          // Fallback to hardcoded test data when real file is not available
-          fileContent = frontmatter ? `${frontmatter}\n${content}` : content;
-          contentSource = 'test data';
-        }
+        // Step 2: Use fixed fixture content so URL expectations stay deterministic
+        const fileContent = frontmatter ? `${frontmatter}\n${content}` : content;
         
         // For debugging: log which content source was used
         if (process.env.DEBUG_TESTS === 'true') {
-          console.log(`\n[${name}] Using ${contentSource}`);
+          console.log(`\n[${name}] Using test data`);
           console.log(`File path: ${libraryId}/${relFile}`);
           console.log(`Content preview: ${fileContent.slice(0, 100)}...`);
         }
@@ -403,6 +455,36 @@ describe('Comprehensive URL Generation System', () => {
         
         expect(result).toBe('https://sap.github.io/ai-sdk/docs/js/langchain/orchestration');
       });
+
+      it('should preserve nested Docusaurus parent paths for numbered docs', () => {
+        const config = getConfigForLibrary('/cloud-sdk-java');
+        const generator = new CloudSdkUrlGenerator('/cloud-sdk-java', config);
+        const content = '---\nid: destination-service\n---\n# Connectivity Features';
+
+        const result = generator.generateUrl({
+          libraryId: '/cloud-sdk-java',
+          relFile: 'features/connectivity/000-overview.mdx',
+          content,
+          config
+        });
+
+        expect(result).toBe('https://sap.github.io/cloud-sdk/docs/java/features/connectivity/destination-service');
+      });
+
+      it('should prefer Docusaurus slug frontmatter over file-derived routes', () => {
+        const config = getConfigForLibrary('/cloud-sdk-js');
+        const generator = new CloudSdkUrlGenerator('/cloud-sdk-js', config);
+        const content = '---\nid: ignored-id\nslug: /features/custom-runtime-route\n---\n# Custom Route';
+
+        const result = generator.generateUrl({
+          libraryId: '/cloud-sdk-js',
+          relFile: 'features/runtime/001-original-name.mdx',
+          content,
+          config
+        });
+
+        expect(result).toBe('https://sap.github.io/cloud-sdk/docs/js/features/custom-runtime-route');
+      });
     });
 
     describe('SapUi5UrlGenerator', () => {
@@ -435,25 +517,55 @@ describe('Comprehensive URL Generation System', () => {
         
         expect(result).toBe('https://sdk.openui5.org/#/api/sap.m.Button');
       });
+
+      it('should derive OpenUI5 sample routes from manifest sample ids', () => {
+        const config = getConfigForLibrary('/openui5-samples');
+        const generator = new SapUi5UrlGenerator('/openui5-samples', config);
+        const content = '{"sap.app":{"id":"sap.ui.unified.sample.ColorPicker"}}';
+
+        const result = generator.generateUrl({
+          libraryId: '/openui5-samples',
+          relFile: 'sap.ui.unified/test/sap/ui/unified/demokit/sample/ColorPickerSimplified/manifest.json',
+          content,
+          config
+        });
+
+        expect(result).toBe('https://sdk.openui5.org/#/entity/sap.ui.unified.ColorPicker/sample/sap.ui.unified.sample.ColorPicker');
+      });
+
+      it('should keep nested OpenUI5 sample sub-files on the sample root route', () => {
+        const config = getConfigForLibrary('/openui5-samples');
+        const generator = new SapUi5UrlGenerator('/openui5-samples', config);
+        const content = '<mvc:View controllerName="sap.m.sample.Slider.Slider"></mvc:View>';
+
+        const result = generator.generateUrl({
+          libraryId: '/openui5-samples',
+          relFile: 'sap.m/test/sap/m/demokit/sample/Slider/view/Slider.view.xml',
+          content,
+          config
+        });
+
+        expect(result).toBe('https://sdk.openui5.org/#/entity/sap.m.Slider/sample/sap.m.sample.Slider');
+      });
     });
 
     describe('CapUrlGenerator', () => {
-      it('should generate docsify-style URLs', () => {
+      it('should generate direct capire documentation URLs', () => {
         const config = getConfigForLibrary('/cap');
         const generator = new CapUrlGenerator('/cap', config);
-        const content = '---\nid: getting-started\n---\n# Getting Started';
+        const content = '# Providing Services';
         
         const result = generator.generateUrl({
           libraryId: '/cap',
-          relFile: 'guides/getting-started.md',
+          relFile: 'guides/providing-services.md',
           content,
           config
         });
         
-        expect(result).toBe('https://cap.cloud.sap/docs/#/guides/getting-started');
+        expect(result).toBe('https://cap.cloud.sap/docs/guides/services/providing-services');
       });
 
-      it('should handle CDS-specific sections', () => {
+      it('should preserve nested CAP documentation paths', () => {
         const config = getConfigForLibrary('/cap');
         const generator = new CapUrlGenerator('/cap', config);
         const content = '---\nslug: cds-types\n---\n# CDS Types';
@@ -465,7 +577,50 @@ describe('Comprehensive URL Generation System', () => {
           config
         });
         
-        expect(result).toBe('https://cap.cloud.sap/docs/#/cds/cds-types');
+        expect(result).toBe('https://cap.cloud.sap/docs/cds/types');
+      });
+
+      it('should map indexed legacy CAP paths to current capire routes', () => {
+        const config = getConfigForLibrary('/cap');
+        const generator = new CapUrlGenerator('/cap', config);
+
+        const cases = [
+          ['about/best-practices.md', 'https://cap.cloud.sap/docs/get-started/concepts'],
+          ['advanced/hana.md', 'https://cap.cloud.sap/docs/guides/databases/hana-native'],
+          ['advanced/hybrid-testing.md', 'https://cap.cloud.sap/docs/tools/cds-bind'],
+          ['advanced/publishing-apis/openapi.md', 'https://cap.cloud.sap/docs/guides/protocols/openapi'],
+          ['get-started/troubleshooting.md', 'https://cap.cloud.sap/docs/get-started/get-help'],
+          ['guides/databases-hana.md', 'https://cap.cloud.sap/docs/guides/databases/hana'],
+          ['guides/deployment/custom-builds.md', 'https://cap.cloud.sap/docs/guides/deploy/build'],
+          ['guides/messaging/event-broker.md', 'https://cap.cloud.sap/docs/guides/events/event-hub'],
+          ['guides/data-privacy/audit-logging.md', 'https://cap.cloud.sap/docs/guides/security/dpp-audit-logging'],
+          ['guides/extensibility/composition.md', 'https://cap.cloud.sap/docs/guides/integration/reuse-and-compose']
+        ] as const;
+
+        for (const [relFile, expected] of cases) {
+          const result = generator.generateUrl({
+            libraryId: '/cap',
+            relFile,
+            content: '# CAP',
+            config
+          });
+
+          expect(result).toBe(expected);
+        }
+      });
+
+      it('should use GitHub blob URLs for indexed CAP files that are not published as site pages', () => {
+        const config = getConfigForLibrary('/cap');
+        const generator = new CapUrlGenerator('/cap', config);
+
+        const result = generator.generateUrl({
+          libraryId: '/cap',
+          relFile: 'CODE_OF_CONDUCT.md',
+          content: '# Contributor Covenant Code of Conduct',
+          config
+        });
+
+        expect(result).toMatch(/^https:\/\/github\.com\/capire\/docs\/blob\/(?:[a-f0-9]{40}|main)\/CODE_OF_CONDUCT\.md$/);
       });
     });
 
@@ -505,16 +660,16 @@ describe('Comprehensive URL Generation System', () => {
       it('should generate GitHub Pages URLs with path transformation', () => {
         const config = getConfigForLibrary('/dsag-abap-leitfaden');
         const generator = new DsagUrlGenerator('/dsag-abap-leitfaden', config);
-        const content = '# Was ist Clean Core?\n\nClean Core ist ein Konzept von SAP...';
+        const content = '---\npermalink: /abap/oo-basics/\n---\n# Ergänzungen und Details zu Themen der Objektorientierung';
         
         const result = generator.generateUrl({
           libraryId: '/dsag-abap-leitfaden',
-          relFile: 'clean-core/what-is-clean-core.md',
+          relFile: 'abap/OO-basics.md',
           content,
           config
         });
         
-        expect(result).toBe('https://marianfoo.github.io/DSAG-ABAP-Guide/clean-core/what-is-clean-core/#was-ist-clean-core');
+        expect(result).toBe('https://marianfoo.github.io/DSAG-ABAP-Guide/abap/oo-basics/#ergänzungen-und-details-zu-themen-der-objektorientierung');
       });
 
       it('should handle root-level documentation', () => {
@@ -529,15 +684,15 @@ describe('Comprehensive URL Generation System', () => {
           config
         });
         
-        expect(result).toBe('https://marianfoo.github.io/DSAG-ABAP-Guide/README/#abap-leitfaden');
+        expect(result).toBe('https://marianfoo.github.io/DSAG-ABAP-Guide/#abap-leitfaden');
       });
     });
 
-    describe('GenericUrlGenerator', () => {
-      it('should handle generic sources with frontmatter', () => {
-        const config = getConfigForLibrary('/ui5-tooling'); // Use a real generic source
-        const generator = new GenericUrlGenerator('/ui5-tooling', config);
-        const content = '---\nid: test-doc\n---\n# Test Document';
+    describe('MkDocsUrlGenerator', () => {
+      it('should generate GitHub Pages URLs with trailing slash and anchors', () => {
+        const config = getConfigForLibrary('/ui5-tooling');
+        const generator = new MkDocsUrlGenerator('/ui5-tooling', config);
+        const content = '# Test Document';
         
         const result = generator.generateUrl({
           libraryId: '/ui5-tooling',
@@ -546,22 +701,113 @@ describe('Comprehensive URL Generation System', () => {
           config
         });
         
-        expect(result).toBe('https://sap.github.io/ui5-tooling/v4/pages/test-doc#test-document');
+        expect(result).toBe('https://ui5.github.io/cli/v4/pages/test/#test-document');
       });
 
-      it('should fallback to filename when no frontmatter', () => {
-        const config = getConfigForLibrary('/ui5-tooling'); // Use a real generic source
-        const generator = new GenericUrlGenerator('/ui5-tooling', config);
-        const content = '# Test Document\n\nSome content...';
+      it('should map index pages to the source homepage', () => {
+        const config = getConfigForLibrary('/cloud-mta-build-tool');
+        const generator = new MkDocsUrlGenerator('/cloud-mta-build-tool', config);
+        const content = '# Cloud MTA Build Tool';
         
         const result = generator.generateUrl({
-          libraryId: '/ui5-tooling',
-          relFile: 'pages/test.md',
+          libraryId: '/cloud-mta-build-tool',
+          relFile: 'index.md',
           content,
           config
         });
         
-        expect(result).toBe('https://sap.github.io/ui5-tooling/v4/pages/test#test-document');
+        expect(result).toBe('https://sap.github.io/cloud-mta-build-tool/#cloud-mta-build-tool');
+      });
+    });
+
+    describe('GithubBlobUrlGenerator', () => {
+      it('should preserve directories and markdown extensions for GitHub blob URLs', () => {
+        const config = getConfigForLibrary('/sap-styleguides');
+        const generator = new GithubBlobUrlGenerator('/sap-styleguides', config);
+        const content = '# Clean ABAP';
+
+        const result = generator.generateUrl({
+          libraryId: '/sap-styleguides',
+          relFile: 'clean-abap/CleanABAP.md',
+          content,
+          config
+        });
+
+        expect(result).toBe('https://github.com/SAP/styleguides/blob/main/clean-abap/CleanABAP.md#clean-abap');
+      });
+    });
+
+    describe('Ui5WebComponentsUrlGenerator', () => {
+      it('should map numbered Docusaurus paths to public docs routes', () => {
+        const config = getConfigForLibrary('/ui5-webcomponents');
+        const generator = new Ui5WebComponentsUrlGenerator('/ui5-webcomponents', config);
+
+        const result = generator.generateUrl({
+          libraryId: '/ui5-webcomponents',
+          relFile: '2-advanced/01-configuration.md',
+          content: '# Configuration',
+          config
+        });
+
+        expect(result).toBe('https://ui5.github.io/webcomponents/docs/advanced/configuration/');
+      });
+    });
+
+    describe('Ui5TypeScriptUrlGenerator', () => {
+      it('should map Markdown pages to the gh-pages HTML output', () => {
+        const config = getConfigForLibrary('/ui5-typescript');
+        const generator = new Ui5TypeScriptUrlGenerator('/ui5-typescript', config);
+
+        const result = generator.generateUrl({
+          libraryId: '/ui5-typescript',
+          relFile: 'faq.md',
+          content: '# FAQ',
+          config
+        });
+
+        expect(result).toBe('https://ui5.github.io/typescript/faq.html#faq');
+      });
+    });
+
+    describe('SapHelpLoioUrlGenerator', () => {
+      it('should build BTP SAP Help URLs from LOIO comments', () => {
+        const config = getConfigForLibrary('/btp-cloud-platform');
+        const generator = new SapHelpLoioUrlGenerator('/btp-cloud-platform', config);
+
+        const result = generator.generateUrl({
+          libraryId: '/btp-cloud-platform',
+          relFile: '20-getting-started/abap-environment-initial-settings-a999fac.md',
+          content: '<!-- loioa999fac2a578468ea0e4e320c82145ce -->\n# ABAP Environment Initial Settings',
+          config
+        });
+
+        expect(result).toBe('https://help.sap.com/docs/BTP/65de2977205c403bbc107264b8eccf4b/a999fac2a578468ea0e4e320c82145ce.html');
+      });
+
+      it('should not fall back to invalid SAP Help paths without a LOIO', () => {
+        const config = getConfigForLibrary('/btp-cloud-platform');
+        const generator = new SapHelpLoioUrlGenerator('/btp-cloud-platform', config);
+
+        const result = generator.generateUrl({
+          libraryId: '/btp-cloud-platform',
+          relFile: 'missing-loio.md',
+          content: '# Missing LOIO',
+          config
+        });
+
+        expect(result).toBeNull();
+      });
+    });
+
+    describe('SAP Community URL normalization', () => {
+      it('should convert relative Khoros URLs to absolute SAP Community URLs', () => {
+        const result = normalizeCommunityUrl('/t5/technology-blogs-by-sap/example/ba-p/123456');
+        expect(result).toBe('https://community.sap.com/t5/technology-blogs-by-sap/example/ba-p/123456');
+      });
+
+      it('should preserve already absolute URLs', () => {
+        const result = normalizeCommunityUrl('https://community.sap.com/t5/example/td-p/42');
+        expect(result).toBe('https://community.sap.com/t5/example/td-p/42');
       });
     });
 

--- a/test/comprehensive-url-generation.test.ts
+++ b/test/comprehensive-url-generation.test.ts
@@ -547,6 +547,21 @@ describe('Comprehensive URL Generation System', () => {
 
         expect(result).toBe('https://sdk.openui5.org/#/entity/sap.m.Slider/sample/sap.m.sample.Slider');
       });
+
+      it('should derive OpenUI5 sample entities from Demokit docuindex metadata', () => {
+        const config = getConfigForLibrary('/openui5-samples');
+        const generator = new SapUi5UrlGenerator('/openui5-samples', config);
+        const content = '{"sap.app":{"id":"sap.uxap.sample.ObjectPageHeaderExpanded"}}';
+
+        const result = generator.generateUrl({
+          libraryId: '/openui5-samples',
+          relFile: 'sap.uxap/test/sap/uxap/demokit/sample/ObjectPageHeaderExpanded/manifest.json',
+          content,
+          config
+        });
+
+        expect(result).toBe('https://sdk.openui5.org/#/entity/sap.uxap.ObjectPageLayout/sample/sap.uxap.sample.ObjectPageHeaderExpanded');
+      });
     });
 
     describe('CapUrlGenerator', () => {

--- a/test/search-response-schema.test.ts
+++ b/test/search-response-schema.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+
+type RequestHandler = (request: unknown, extra?: unknown) => unknown;
+
+function getHandler(server: Server, method: string): RequestHandler {
+  const handlers: Map<string, RequestHandler> = (server as unknown as { _requestHandlers: Map<string, RequestHandler> })._requestHandlers;
+  const handler = handlers.get(method);
+  if (!handler) {
+    throw new Error(`Handler not registered for method: ${method}`);
+  }
+  return handler;
+}
+
+describe('search response schema', () => {
+  it('returns schema-compliant empty results instead of an MCP schema error', async () => {
+    vi.resetModules();
+    vi.doMock('../src/lib/search.js', () => ({
+      search: vi.fn(async () => [])
+    }));
+
+    const { BaseServerHandler } = await import('../src/lib/BaseServerHandler.js');
+    const server = new Server({
+      name: 'Test Server',
+      version: '1.0.0'
+    }, {
+      capabilities: {
+        tools: {}
+      }
+    });
+
+    BaseServerHandler.configureServer(server);
+    const handler = getHandler(server, 'tools/call');
+    const request = CallToolRequestSchema.parse({
+      method: 'tools/call',
+      params: {
+        name: 'search',
+        arguments: {
+          query: 'query-that-should-not-match-anything',
+          sources: ['wdi5']
+        }
+      }
+    });
+
+    const result = await handler(request) as any;
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(payload.results).toEqual([]);
+    expect(result.structuredContent.results).toEqual([]);
+    expect(payload.error).toContain('No results');
+  });
+});

--- a/test/source-url-matrix.test.ts
+++ b/test/source-url-matrix.test.ts
@@ -137,6 +137,12 @@ const sourceUrlCases: UrlCase[] = [
     content: '{"sap.app":{"id":"sap.ui.unified.sample.ColorPicker"}}',
     expectedUrl: 'https://sdk.openui5.org/#/entity/sap.ui.unified.ColorPicker/sample/sap.ui.unified.sample.ColorPicker'
   },
+  {
+    libraryId: '/openui5-samples',
+    relFile: 'sap.uxap/test/sap/uxap/demokit/sample/ObjectPageHeaderExpanded/manifest.json',
+    content: '{"sap.app":{"id":"sap.uxap.sample.ObjectPageHeaderExpanded"}}',
+    expectedUrl: 'https://sdk.openui5.org/#/entity/sap.uxap.ObjectPageLayout/sample/sap.uxap.sample.ObjectPageHeaderExpanded'
+  },
 
   // wdi5
   {

--- a/test/source-url-matrix.test.ts
+++ b/test/source-url-matrix.test.ts
@@ -1,0 +1,753 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { generateDocumentationUrl } from '../src/lib/url-generation/index.js';
+import { getAllDocUrlConfigs, getDocUrlConfig } from '../src/lib/metadata.js';
+import { normalizeCommunityUrl } from '../src/lib/communityBestMatch.js';
+import { searchSapHelp } from '../src/lib/sapHelp.js';
+
+type UrlCase = {
+  libraryId: string;
+  relFile: string;
+  content: string;
+  expectedUrl: string;
+};
+
+const fm = (id: string, title = 'Title') => `---\nid: ${id}\ntitle: ${title}\n---\n# ${title}`;
+const loio = (id: string, title = 'Title') => `<!-- loio${id} -->\n\n# ${title}`;
+const copyLoio = (id: string, title = 'Title') => `<!-- copy${id} -->\n\n# ${title}`;
+
+const sourceUrlCases: UrlCase[] = [
+  // SAPUI5
+  {
+    libraryId: '/sapui5',
+    relFile: 'index.md',
+    content: '# SAPUI5: UI Development Toolkit for HTML5\n\n- [SAPUI5: UI Development Toolkit for HTML5](sapui5-ui-development-toolkit-for-html5-95d113b.md)',
+    expectedUrl: 'https://ui5.sap.com/#/topic/95d113be50ae40d5b0b562b84d715227'
+  },
+  {
+    libraryId: '/sapui5',
+    relFile: 'sapui5-ui-development-toolkit-for-html5-95d113b.md',
+    content: loio('95d113be50ae40d5b0b562b84d715227', 'SAPUI5: UI Development Toolkit for HTML5'),
+    expectedUrl: 'https://ui5.sap.com/#/topic/95d113be50ae40d5b0b562b84d715227'
+  },
+  {
+    libraryId: '/sapui5',
+    relFile: '02_Read-Me-First/read-me-first-167193c.md',
+    content: loio('167193ced54c41c3961d7df3479d7bbe', 'Read Me First'),
+    expectedUrl: 'https://ui5.sap.com/#/topic/167193ced54c41c3961d7df3479d7bbe'
+  },
+  {
+    libraryId: '/sapui5',
+    relFile: '02_Read-Me-First/supported-library-combinations-363cd16.md',
+    content: loio('363cd16eba1f45babe3f661f321a7820', 'Supported Library Combinations'),
+    expectedUrl: 'https://ui5.sap.com/#/topic/363cd16eba1f45babe3f661f321a7820'
+  },
+  {
+    libraryId: '/sapui5',
+    relFile: '04_Essentials/test-recorder-dac59fa.md',
+    content: copyLoio('dac59fadd5f9419d986f74ba602c6d29', 'Test Recorder'),
+    expectedUrl: 'https://ui5.sap.com/#/topic/dac59fadd5f9419d986f74ba602c6d29'
+  },
+
+  // CAP
+  {
+    libraryId: '/cap',
+    relFile: 'node.js/cds-log.md',
+    content: '# Logging',
+    expectedUrl: 'https://cap.cloud.sap/docs/node.js/cds-log'
+  },
+  {
+    libraryId: '/cap',
+    relFile: 'guides/providing-services.md',
+    content: '# Providing Services',
+    expectedUrl: 'https://cap.cloud.sap/docs/guides/services/providing-services'
+  },
+  {
+    libraryId: '/cap',
+    relFile: 'cds/cdl.md',
+    content: '# CDL',
+    expectedUrl: 'https://cap.cloud.sap/docs/cds/cdl'
+  },
+  {
+    libraryId: '/cap',
+    relFile: 'about/best-practices.md',
+    content: '# Best Practices by CAP',
+    expectedUrl: 'https://cap.cloud.sap/docs/get-started/concepts'
+  },
+  {
+    libraryId: '/cap',
+    relFile: 'advanced/hana.md',
+    content: '# Using Native SAP HANA Artifacts',
+    expectedUrl: 'https://cap.cloud.sap/docs/guides/databases/hana-native'
+  },
+  {
+    libraryId: '/cap',
+    relFile: 'get-started/troubleshooting.md',
+    content: '# Troubleshooting',
+    expectedUrl: 'https://cap.cloud.sap/docs/get-started/get-help'
+  },
+
+  // OpenUI5 API
+  {
+    libraryId: '/openui5-api',
+    relFile: 'sap.m/src/sap/m/Button.js',
+    content: 'sap.ui.define([]);',
+    expectedUrl: 'https://sdk.openui5.org/#/api/sap.m.Button'
+  },
+  {
+    libraryId: '/openui5-api',
+    relFile: 'sap.ui.table/src/sap/ui/table/Table.js',
+    content: 'sap.ui.define([]);',
+    expectedUrl: 'https://sdk.openui5.org/#/api/sap.ui.table.Table'
+  },
+  {
+    libraryId: '/openui5-api',
+    relFile: 'sap.ui.core/src/sap/ui/core/mvc/Controller.js',
+    content: 'sap.ui.define([]);',
+    expectedUrl: 'https://sdk.openui5.org/#/api/sap.ui.core.mvc.Controller'
+  },
+
+  // OpenUI5 samples
+  {
+    libraryId: '/openui5-samples',
+    relFile: 'sap.m/test/sap/m/demokit/sample/ButtonWithBadge/Component.js',
+    content: 'UIComponent.extend("sap.m.sample.ButtonWithBadge.Component", {});',
+    expectedUrl: 'https://sdk.openui5.org/#/entity/sap.m.Button/sample/sap.m.sample.ButtonWithBadge'
+  },
+  {
+    libraryId: '/openui5-samples',
+    relFile: 'sap.m/test/sap/m/demokit/sample/Slider/manifest.json',
+    content: '{"sap.app":{"id":"sap.m.sample.Slider"}}',
+    expectedUrl: 'https://sdk.openui5.org/#/entity/sap.m.Slider/sample/sap.m.sample.Slider'
+  },
+  {
+    libraryId: '/openui5-samples',
+    relFile: 'sap.m/test/sap/m/demokit/sample/Slider/view/Slider.view.xml',
+    content: '<mvc:View controllerName="sap.m.sample.Slider.Slider"></mvc:View>',
+    expectedUrl: 'https://sdk.openui5.org/#/entity/sap.m.Slider/sample/sap.m.sample.Slider'
+  },
+  {
+    libraryId: '/openui5-samples',
+    relFile: 'sap.ui.table/test/sap/ui/table/demokit/sample/Basic/manifest.json',
+    content: '{"sap.app":{"id":"sap.ui.table.sample.Basic"}}',
+    expectedUrl: 'https://sdk.openui5.org/#/entity/sap.ui.table.Table/sample/sap.ui.table.sample.Basic'
+  },
+  {
+    libraryId: '/openui5-samples',
+    relFile: 'sap.ui.unified/test/sap/ui/unified/demokit/sample/ColorPickerSimplified/manifest.json',
+    content: '{"sap.app":{"id":"sap.ui.unified.sample.ColorPicker"}}',
+    expectedUrl: 'https://sdk.openui5.org/#/entity/sap.ui.unified.ColorPicker/sample/sap.ui.unified.sample.ColorPicker'
+  },
+
+  // wdi5
+  {
+    libraryId: '/wdi5',
+    relFile: 'README.md',
+    content: '# wdi5',
+    expectedUrl: 'https://ui5-community.github.io/wdi5/#/'
+  },
+  {
+    libraryId: '/wdi5',
+    relFile: 'locators.md',
+    content: '# Locators',
+    expectedUrl: 'https://ui5-community.github.io/wdi5/#/locators'
+  },
+  {
+    libraryId: '/wdi5',
+    relFile: 'configuration.md',
+    content: '# Configuration',
+    expectedUrl: 'https://ui5-community.github.io/wdi5/#/configuration'
+  },
+
+  // UI5 Tooling
+  {
+    libraryId: '/ui5-tooling',
+    relFile: 'pages/Builder.md',
+    content: '# UI5 Builder',
+    expectedUrl: 'https://ui5.github.io/cli/v4/pages/Builder/#ui5-builder'
+  },
+  {
+    libraryId: '/ui5-tooling',
+    relFile: 'pages/Configuration.md',
+    content: '# Configuration',
+    expectedUrl: 'https://ui5.github.io/cli/v4/pages/Configuration/#configuration'
+  },
+  {
+    libraryId: '/ui5-tooling',
+    relFile: 'updates/migrate-v4.md',
+    content: '# Migrate to v4',
+    expectedUrl: 'https://ui5.github.io/cli/v4/updates/migrate-v4/#migrate-to-v4'
+  },
+
+  // Cloud MTA Build Tool
+  {
+    libraryId: '/cloud-mta-build-tool',
+    relFile: 'download.md',
+    content: '# Download',
+    expectedUrl: 'https://sap.github.io/cloud-mta-build-tool/download/#download'
+  },
+  {
+    libraryId: '/cloud-mta-build-tool',
+    relFile: 'configuration.md',
+    content: '# Configuration',
+    expectedUrl: 'https://sap.github.io/cloud-mta-build-tool/configuration/#configuration'
+  },
+  {
+    libraryId: '/cloud-mta-build-tool',
+    relFile: 'usage.md',
+    content: '# Usage',
+    expectedUrl: 'https://sap.github.io/cloud-mta-build-tool/usage/#usage'
+  },
+
+  // UI5 Web Components
+  {
+    libraryId: '/ui5-webcomponents',
+    relFile: '1-getting-started/01-first-steps.md',
+    content: '# First Steps',
+    expectedUrl: 'https://ui5.github.io/webcomponents/docs/getting-started/first-steps/'
+  },
+  {
+    libraryId: '/ui5-webcomponents',
+    relFile: '2-advanced/01-configuration.md',
+    content: '# Configuration',
+    expectedUrl: 'https://ui5.github.io/webcomponents/docs/advanced/configuration/'
+  },
+  {
+    libraryId: '/ui5-webcomponents',
+    relFile: '4-development/03-properties.md',
+    content: '# Properties',
+    expectedUrl: 'https://ui5.github.io/webcomponents/docs/development/properties/'
+  },
+
+  // Cloud SDK JavaScript
+  {
+    libraryId: '/cloud-sdk-js',
+    relFile: 'getting-started.mdx',
+    content: fm('getting-started', 'Getting Started'),
+    expectedUrl: 'https://sap.github.io/cloud-sdk/docs/js/getting-started'
+  },
+  {
+    libraryId: '/cloud-sdk-js',
+    relFile: 'guides/debug-remote-app.mdx',
+    content: fm('remote-debugging', 'Remotely debug an application on SAP BTP'),
+    expectedUrl: 'https://sap.github.io/cloud-sdk/docs/js/guides/remote-debugging'
+  },
+  {
+    libraryId: '/cloud-sdk-js',
+    relFile: 'features/connectivity/destination.mdx',
+    content: fm('destinations', 'Destinations'),
+    expectedUrl: 'https://sap.github.io/cloud-sdk/docs/js/features/connectivity/destinations'
+  },
+
+  // Cloud SDK Java
+  {
+    libraryId: '/cloud-sdk-java',
+    relFile: 'faq.mdx',
+    content: fm('frequently-asked-questions', 'Frequently Asked Questions'),
+    expectedUrl: 'https://sap.github.io/cloud-sdk/docs/java/frequently-asked-questions'
+  },
+  {
+    libraryId: '/cloud-sdk-java',
+    relFile: 'features/odata/overview.mdx',
+    content: fm('overview', 'OData'),
+    expectedUrl: 'https://sap.github.io/cloud-sdk/docs/java/features/odata/overview'
+  },
+  {
+    libraryId: '/cloud-sdk-java',
+    relFile: 'features/connectivity/000-overview.mdx',
+    content: fm('destination-service', 'Connectivity Features'),
+    expectedUrl: 'https://sap.github.io/cloud-sdk/docs/java/features/connectivity/destination-service'
+  },
+
+  // Cloud SDK AI JavaScript
+  {
+    libraryId: '/cloud-sdk-ai-js',
+    relFile: 'getting-started.mdx',
+    content: fm('getting-started', 'Getting Started'),
+    expectedUrl: 'https://sap.github.io/ai-sdk/docs/js/getting-started'
+  },
+  {
+    libraryId: '/cloud-sdk-ai-js',
+    relFile: 'orchestration/chat-completion.mdx',
+    content: fm('chat-completion', 'Chat Completion'),
+    expectedUrl: 'https://sap.github.io/ai-sdk/docs/js/orchestration/chat-completion'
+  },
+  {
+    libraryId: '/cloud-sdk-ai-js',
+    relFile: 'langchain/orchestration.mdx',
+    content: fm('orchestration', 'Orchestration Integration'),
+    expectedUrl: 'https://sap.github.io/ai-sdk/docs/js/langchain/orchestration'
+  },
+
+  // Cloud SDK AI Java
+  {
+    libraryId: '/cloud-sdk-ai-java',
+    relFile: 'getting-started.mdx',
+    content: fm('getting-started', 'Getting Started'),
+    expectedUrl: 'https://sap.github.io/ai-sdk/docs/java/getting-started'
+  },
+  {
+    libraryId: '/cloud-sdk-ai-java',
+    relFile: 'orchestration/chat-completion.mdx',
+    content: fm('chat-completion', 'Chat Completion'),
+    expectedUrl: 'https://sap.github.io/ai-sdk/docs/java/orchestration/chat-completion'
+  },
+  {
+    libraryId: '/cloud-sdk-ai-java',
+    relFile: 'spring-ai/orchestration.mdx',
+    content: fm('orchestration', 'Orchestration Integration'),
+    expectedUrl: 'https://sap.github.io/ai-sdk/docs/java/spring-ai/orchestration'
+  },
+
+  // UI5 TypeScript
+  {
+    libraryId: '/ui5-typescript',
+    relFile: 'README.md',
+    content: '# UI5-TypeScript',
+    expectedUrl: 'https://ui5.github.io/typescript#ui5-typescript'
+  },
+  {
+    libraryId: '/ui5-typescript',
+    relFile: 'faq.md',
+    content: '# FAQ - Frequently Asked Questions for the UI5 Type Definitions',
+    expectedUrl: 'https://ui5.github.io/typescript/faq.html#faq---frequently-asked-questions-for-the-ui5-type-definitions'
+  },
+  {
+    libraryId: '/ui5-typescript',
+    relFile: 'technical.md',
+    content: '# Technical Background',
+    expectedUrl: 'https://ui5.github.io/typescript/technical.html#technical-background'
+  },
+
+  // UI5 Spreadsheet Importer
+  {
+    libraryId: '/ui5-cc-spreadsheetimporter',
+    relFile: 'pages/Checks.md',
+    content: '## Error Types',
+    expectedUrl: 'https://docs.spreadsheet-importer.com/pages/Checks/#error-types'
+  },
+  {
+    libraryId: '/ui5-cc-spreadsheetimporter',
+    relFile: 'pages/Configuration.md',
+    content: '# Configuration',
+    expectedUrl: 'https://docs.spreadsheet-importer.com/pages/Configuration/#configuration'
+  },
+  {
+    libraryId: '/ui5-cc-spreadsheetimporter',
+    relFile: 'pages/GettingStarted.md',
+    content: '## Deployment Strategy',
+    expectedUrl: 'https://docs.spreadsheet-importer.com/pages/GettingStarted/#deployment-strategy'
+  },
+
+  // GitHub blob documentation and samples
+  {
+    libraryId: '/abap-cheat-sheets',
+    relFile: '01_Internal_Tables.md',
+    content: '# Internal Tables',
+    expectedUrl: 'https://github.com/SAP-samples/abap-cheat-sheets/blob/main/01_Internal_Tables.md#internal-tables'
+  },
+  {
+    libraryId: '/abap-cheat-sheets',
+    relFile: '03_ABAP_SQL.md',
+    content: '# ABAP SQL',
+    expectedUrl: 'https://github.com/SAP-samples/abap-cheat-sheets/blob/main/03_ABAP_SQL.md#abap-sql'
+  },
+  {
+    libraryId: '/abap-cheat-sheets',
+    relFile: '08_EML_ABAP_for_RAP.md',
+    content: '# ABAP for RAP: Entity Manipulation Language (ABAP EML)',
+    expectedUrl: 'https://github.com/SAP-samples/abap-cheat-sheets/blob/main/08_EML_ABAP_for_RAP.md#abap-for-rap-entity-manipulation-language-abap-eml'
+  },
+  {
+    libraryId: '/sap-styleguides',
+    relFile: 'clean-abap/CleanABAP.md',
+    content: '# Clean ABAP',
+    expectedUrl: 'https://github.com/SAP/styleguides/blob/main/clean-abap/CleanABAP.md#clean-abap'
+  },
+  {
+    libraryId: '/sap-styleguides',
+    relFile: 'abap-code-review/ABAPCodeReview.md',
+    content: '# ABAP Code Reviews',
+    expectedUrl: 'https://github.com/SAP/styleguides/blob/main/abap-code-review/ABAPCodeReview.md#abap-code-reviews'
+  },
+  {
+    libraryId: '/sap-styleguides',
+    relFile: 'clean-abap/sub-sections/ModernABAPLanguageElements.md',
+    content: '# Modern ABAP Language Elements',
+    expectedUrl: 'https://github.com/SAP/styleguides/blob/main/clean-abap/sub-sections/ModernABAPLanguageElements.md#modern-abap-language-elements'
+  },
+
+  // DSAG ABAP Guide
+  {
+    libraryId: '/dsag-abap-leitfaden',
+    relFile: 'clean-core/what-is-clean-core.md',
+    content: '---\npermalink: /clean-core/what-is-clean-core/\n---\n# Was ist Clean Core?',
+    expectedUrl: 'https://marianfoo.github.io/DSAG-ABAP-Guide/clean-core/what-is-clean-core/#was-ist-clean-core'
+  },
+  {
+    libraryId: '/dsag-abap-leitfaden',
+    relFile: 'abap/OO-basics.md',
+    content: '---\npermalink: /abap/oo-basics/\n---\n# Ergänzungen und Details zu Themen der Objektorientierung',
+    expectedUrl: 'https://marianfoo.github.io/DSAG-ABAP-Guide/abap/oo-basics/#ergänzungen-und-details-zu-themen-der-objektorientierung'
+  },
+  {
+    libraryId: '/dsag-abap-leitfaden',
+    relFile: 'testing/recommendations.md',
+    content: '---\npermalink: /testing/recommendations/\n---\n# Empfehlungen',
+    expectedUrl: 'https://marianfoo.github.io/DSAG-ABAP-Guide/testing/recommendations/#empfehlungen'
+  },
+
+  // ABAP Fiori Showcase
+  {
+    libraryId: '/abap-fiori-showcase',
+    relFile: '01_general_features.md',
+    content: '# General Features',
+    expectedUrl: 'https://github.com/SAP-samples/abap-platform-fiori-feature-showcase/blob/main/01_general_features.md#general-features'
+  },
+  {
+    libraryId: '/abap-fiori-showcase',
+    relFile: '02_list_report_header.md',
+    content: '# List Report Header',
+    expectedUrl: 'https://github.com/SAP-samples/abap-platform-fiori-feature-showcase/blob/main/02_list_report_header.md#list-report-header'
+  },
+  {
+    libraryId: '/abap-fiori-showcase',
+    relFile: '04_object_page_general.md',
+    content: '# Object Page General',
+    expectedUrl: 'https://github.com/SAP-samples/abap-platform-fiori-feature-showcase/blob/main/04_object_page_general.md#object-page-general'
+  },
+
+  // CAP Fiori Showcase
+  {
+    libraryId: '/cap-fiori-showcase',
+    relFile: 'README.md',
+    content: '# SAP Fiori Elements for OData V4 Feature Showcase',
+    expectedUrl: 'https://github.com/SAP-samples/fiori-elements-feature-showcase/blob/main/README.md#sap-fiori-elements-for-odata-v4-feature-showcase'
+  },
+  {
+    libraryId: '/cap-fiori-showcase',
+    relFile: 'app/services.cds',
+    content: 'service CatalogService {}',
+    expectedUrl: 'https://github.com/SAP-samples/fiori-elements-feature-showcase/blob/main/app/services.cds?plain=1'
+  },
+  {
+    libraryId: '/cap-fiori-showcase',
+    relFile: 'db/schema.cds',
+    content: 'namespace sap.fe.showcase;',
+    expectedUrl: 'https://github.com/SAP-samples/fiori-elements-feature-showcase/blob/main/db/schema.cds?plain=1'
+  },
+
+  // ABAP RAP sample repositories
+  {
+    libraryId: '/abap-platform-rap-opensap',
+    relFile: 'README.md',
+    content: '# Welcome to the ABAP RESTful Application Programming Model (RAP) openSAP samples',
+    expectedUrl: 'https://github.com/SAP-samples/abap-platform-rap-opensap/blob/main/README.md#welcome-to-the-abap-restful-application-programming-model-rap-opensap-samples'
+  },
+  {
+    libraryId: '/abap-platform-rap-opensap',
+    relFile: 'week1/README.md',
+    content: '# Week 1',
+    expectedUrl: 'https://github.com/SAP-samples/abap-platform-rap-opensap/blob/main/week1/README.md#week-1'
+  },
+  {
+    libraryId: '/abap-platform-rap-opensap',
+    relFile: 'week1/unit5.md',
+    content: '# HANDS-ON EXERCISE FOR WEEK 1 UNIT 5: PREPARING YOUR ABAP DEVELOPMENT ENVIRONMENT',
+    expectedUrl: 'https://github.com/SAP-samples/abap-platform-rap-opensap/blob/main/week1/unit5.md#hands-on-exercise-for-week-1-unit-5-preparing-your-abap-development-environment'
+  },
+  {
+    libraryId: '/cloud-abap-rap',
+    relFile: 'README.md',
+    content: '# Description',
+    expectedUrl: 'https://github.com/SAP-samples/cloud-abap-rap/blob/main/README.md#description'
+  },
+  {
+    libraryId: '/cloud-abap-rap',
+    relFile: 'optional_parameters.md',
+    content: '# Optional parameters for workshops or other advanced scenarios',
+    expectedUrl: 'https://github.com/SAP-samples/cloud-abap-rap/blob/main/optional_parameters.md#optional-parameters-for-workshops-or-other-advanced-scenarios'
+  },
+  {
+    libraryId: '/cloud-abap-rap',
+    relFile: 'how_to_managed_uuid.md',
+    content: '# How to generate a RAP BO using table with UUID based key fields',
+    expectedUrl: 'https://github.com/SAP-samples/cloud-abap-rap/blob/main/how_to_managed_uuid.md#how-to-generate-a-rap-bo-using-table-with-uuid-based-key-fields'
+  },
+  {
+    libraryId: '/abap-platform-reuse-services',
+    relFile: 'README.md',
+    content: '# Reuse services in ABAP Cloud',
+    expectedUrl: 'https://github.com/SAP-samples/abap-platform-reuse-services/blob/main/README.md#reuse-services-in-abap-cloud'
+  },
+  {
+    libraryId: '/abap-platform-reuse-services',
+    relFile: 'src/zreusecl_test_send_email.clas.abap',
+    content: 'CLASS zreusecl_test_send_email DEFINITION.',
+    expectedUrl: 'https://github.com/SAP-samples/abap-platform-reuse-services/blob/main/src/zreusecl_test_send_email.clas.abap?plain=1'
+  },
+  {
+    libraryId: '/abap-platform-reuse-services',
+    relFile: 'src/zreuseif_002.intf.abap',
+    content: 'INTERFACE zreuseif_002 PUBLIC.',
+    expectedUrl: 'https://github.com/SAP-samples/abap-platform-reuse-services/blob/main/src/zreuseif_002.intf.abap?plain=1'
+  },
+
+  // ABAP keyword docs
+  {
+    libraryId: '/abap-docs-standard',
+    relFile: 'ABAPADD.md',
+    content: '# ADD',
+    expectedUrl: 'https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/ABAPADD.html'
+  },
+  {
+    libraryId: '/abap-docs-standard',
+    relFile: 'ABAPSELECT.md',
+    content: '# SELECT',
+    expectedUrl: 'https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/ABAPSELECT.html'
+  },
+  {
+    libraryId: '/abap-docs-standard',
+    relFile: 'ABAPLOOP.md',
+    content: '# LOOP',
+    expectedUrl: 'https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/ABAPLOOP.html'
+  },
+  {
+    libraryId: '/abap-docs-cloud',
+    relFile: 'ABAPADD.md',
+    content: '# ADD',
+    expectedUrl: 'https://help.sap.com/doc/abapdocu_cp_index_htm/CLOUD/en-US/ABAPADD.html'
+  },
+  {
+    libraryId: '/abap-docs-cloud',
+    relFile: 'ABAPALIASES.md',
+    content: '# ALIASES',
+    expectedUrl: 'https://help.sap.com/doc/abapdocu_cp_index_htm/CLOUD/en-US/ABAPALIASES.html'
+  },
+  {
+    libraryId: '/abap-docs-cloud',
+    relFile: 'ABAPAPPEND.md',
+    content: '# APPEND',
+    expectedUrl: 'https://help.sap.com/doc/abapdocu_cp_index_htm/CLOUD/en-US/ABAPAPPEND.html'
+  },
+
+  // SAP Help LOIO docs
+  {
+    libraryId: '/btp-cloud-platform',
+    relFile: 'sap-business-technology-platform-6a2c1ab.md',
+    content: loio('6a2c1ab5a31b4ed9a2ce17a5329e1dd8', 'SAP Business Technology Platform'),
+    expectedUrl: 'https://help.sap.com/docs/BTP/65de2977205c403bbc107264b8eccf4b/6a2c1ab5a31b4ed9a2ce17a5329e1dd8.html'
+  },
+  {
+    libraryId: '/btp-cloud-platform',
+    relFile: 'index.md',
+    content: '# SAP Business Technology Platform',
+    expectedUrl: 'https://help.sap.com/docs/BTP/65de2977205c403bbc107264b8eccf4b'
+  },
+  {
+    libraryId: '/btp-cloud-platform',
+    relFile: '20-getting-started/creating-an-abap-system-50b32f1.md',
+    content: loio('50b32f144e184154987a06e4b55ce447', 'Creating an ABAP System'),
+    expectedUrl: 'https://help.sap.com/docs/BTP/65de2977205c403bbc107264b8eccf4b/50b32f144e184154987a06e4b55ce447.html'
+  },
+  {
+    libraryId: '/btp-cloud-platform',
+    relFile: '70-getting-support/support-components-08d1103.md',
+    content: loio('08d1103928fb42f3a73b3f425e00e13c', 'Support Components'),
+    expectedUrl: 'https://help.sap.com/docs/BTP/65de2977205c403bbc107264b8eccf4b/08d1103928fb42f3a73b3f425e00e13c.html'
+  },
+  {
+    libraryId: '/sap-artificial-intelligence',
+    relFile: 'sap-ai-core/sap-ai-core-overview-88e0078.md',
+    content: loio('88e007863ca545438e274cbf6ce2d7c6', 'SAP AI Core Overview'),
+    expectedUrl: 'https://help.sap.com/docs/AI_CORE/2d6c5984063c40a59eda62f4a9135bee/88e007863ca545438e274cbf6ce2d7c6.html?version=CLOUD'
+  },
+  {
+    libraryId: '/sap-artificial-intelligence',
+    relFile: 'sap-ai-core/index.md',
+    content: '# SAP AI Core',
+    expectedUrl: 'https://help.sap.com/docs/AI_CORE/2d6c5984063c40a59eda62f4a9135bee?version=CLOUD'
+  },
+  {
+    libraryId: '/sap-artificial-intelligence',
+    relFile: 'sap-ai-core/delete-a-docker-registry-secret-5ff30f0.md',
+    content: loio('5ff30f0332b8452d97ed77edf746714a', 'Delete a Docker Registry Secret'),
+    expectedUrl: 'https://help.sap.com/docs/AI_CORE/2d6c5984063c40a59eda62f4a9135bee/5ff30f0332b8452d97ed77edf746714a.html?version=CLOUD'
+  },
+  {
+    libraryId: '/sap-artificial-intelligence',
+    relFile: 'sap-ai-launchpad/using-sap-ai-launchpad-bbc7e21.md',
+    content: loio('bbc7e21629ce4aef87d85c30cc8b1be8', 'Using SAP AI Launchpad'),
+    expectedUrl: 'https://help.sap.com/docs/AI_LAUNCHPAD/92d77f26188e4582897b9106b9cb72e0/bbc7e21629ce4aef87d85c30cc8b1be8.html?version=CLOUD'
+  },
+  {
+    libraryId: '/sap-artificial-intelligence',
+    relFile: 'sap-ai-launchpad/index.md',
+    content: '# SAP AI Launchpad',
+    expectedUrl: 'https://help.sap.com/docs/AI_LAUNCHPAD/92d77f26188e4582897b9106b9cb72e0?version=CLOUD'
+  },
+
+  // Terraform Registry
+  {
+    libraryId: '/terraform-provider-btp',
+    relFile: 'docs/index.md',
+    content: '# Terraform Provider for SAP BTP',
+    expectedUrl: 'https://registry.terraform.io/providers/SAP/btp/latest/docs'
+  },
+  {
+    libraryId: '/terraform-provider-btp',
+    relFile: 'docs/data-sources/subaccount.md',
+    content: '# btp_subaccount (Data Source)',
+    expectedUrl: 'https://registry.terraform.io/providers/SAP/btp/latest/docs/data-sources/subaccount'
+  },
+  {
+    libraryId: '/terraform-provider-btp',
+    relFile: 'docs/resources/subaccount.md',
+    content: '# btp_subaccount (Resource)',
+    expectedUrl: 'https://registry.terraform.io/providers/SAP/btp/latest/docs/resources/subaccount'
+  },
+
+  // SAP Architecture Center
+  {
+    libraryId: '/architecture-center',
+    relFile: 'RA0001/readme.md',
+    content: '---\nslug: /ref-arch/fbdc46aaae\n---\n# Designing Event-Driven Applications',
+    expectedUrl: 'https://architecture.learning.sap.com/docs/ref-arch/fbdc46aaae'
+  },
+  {
+    libraryId: '/architecture-center',
+    relFile: 'RA0005/readme.md',
+    content: '---\nslug: /ref-arch/e5eb3b9b1d\n---\n# Generative AI on SAP BTP',
+    expectedUrl: 'https://architecture.learning.sap.com/docs/ref-arch/e5eb3b9b1d'
+  },
+  {
+    libraryId: '/architecture-center',
+    relFile: 'RA0010/readme.md',
+    content: '---\nslug: /ref-arch/1311c18c17\n---\n# Establish a central entry point with SAP Build Work Zone',
+    expectedUrl: 'https://architecture.learning.sap.com/docs/ref-arch/1311c18c17'
+  },
+
+  // TechEd 2025 DT260
+  {
+    libraryId: '/teched2025-dt260',
+    relFile: 'README.md',
+    content: '# DT260 - Modernize classic extensions to clean core in Cloud ERP Private',
+    expectedUrl: 'https://github.com/SAP-samples/teched2025-DT260/blob/main/README.md#dt260---modernize-classic-extensions-to-clean-core-in-cloud-erp-private'
+  },
+  {
+    libraryId: '/teched2025-dt260',
+    relFile: 'exercises/ex0/README.md',
+    content: '# Getting Started',
+    expectedUrl: 'https://github.com/SAP-samples/teched2025-DT260/blob/main/exercises/ex0/README.md#getting-started'
+  },
+  {
+    libraryId: '/teched2025-dt260',
+    relFile: 'exercises/ex1/README.md',
+    content: '# Exercise 1 - Modernize the Flight Evaluation application with ABAP Cloud',
+    expectedUrl: 'https://github.com/SAP-samples/teched2025-DT260/blob/main/exercises/ex1/README.md#exercise-1---modernize-the-flight-evaluation-application-with-abap-cloud'
+  }
+];
+
+describe('source URL matrix', () => {
+  it.each(sourceUrlCases)('$libraryId $relFile', ({ libraryId, relFile, content, expectedUrl }) => {
+    const config = getDocUrlConfig(libraryId);
+    expect(config, `missing URL config for ${libraryId}`).toBeTruthy();
+
+    const result = generateDocumentationUrl(libraryId, relFile, content, config!);
+    expect(result).toBe(expectedUrl);
+  });
+
+  it('covers at least three URL cases for every configured source', () => {
+    const counts = new Map<string, number>();
+    for (const testCase of sourceUrlCases) {
+      counts.set(testCase.libraryId, (counts.get(testCase.libraryId) || 0) + 1);
+    }
+
+    const configuredLibraryIds = Object.keys(getAllDocUrlConfigs()).sort();
+    const undercovered = configuredLibraryIds
+      .map(libraryId => [libraryId, counts.get(libraryId) || 0] as const)
+      .filter(([, count]) => count < 3);
+
+    expect(undercovered).toEqual([]);
+  });
+});
+
+describe('online source URL normalization', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    global.sapHelpSearchCache = undefined;
+    vi.restoreAllMocks();
+  });
+
+  it('normalizes SAP Help search result URLs to absolute help.sap.com URLs', async () => {
+    global.fetch = vi.fn(async () => new Response(JSON.stringify({
+      data: {
+        results: [
+          {
+            loio: 'a',
+            title: 'Relative docs URL',
+            url: '/docs/BTP/65de2977205c403bbc107264b8eccf4b/6a2c1ab5a31b4ed9a2ce17a5329e1dd8.html'
+          },
+          {
+            loio: 'b',
+            title: 'Absolute docs URL',
+            url: 'https://help.sap.com/docs/AI_CORE/2d6c5984063c40a59eda62f4a9135bee/88e007863ca545438e274cbf6ce2d7c6.html?version=CLOUD'
+          },
+          {
+            loio: 'c',
+            title: 'Relative doc URL without leading slash',
+            url: 'doc/abapdocu_latest_index_htm/latest/en-US/ABAPADD.html'
+          }
+        ]
+      }
+    }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' }
+    })) as any;
+
+    const response = await searchSapHelp('url normalization');
+
+    expect(response.results.map(result => result.url)).toEqual([
+      'https://help.sap.com/docs/BTP/65de2977205c403bbc107264b8eccf4b/6a2c1ab5a31b4ed9a2ce17a5329e1dd8.html',
+      'https://help.sap.com/docs/AI_CORE/2d6c5984063c40a59eda62f4a9135bee/88e007863ca545438e274cbf6ce2d7c6.html?version=CLOUD',
+      'https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/ABAPADD.html'
+    ]);
+  });
+
+  it('creates stable SAP Help IDs for hits without LOIO values', async () => {
+    global.fetch = vi.fn(async () => new Response(JSON.stringify({
+      data: {
+        results: [
+          {
+            title: 'SAP AI Launchpad User Guide',
+            url: '/doc/sap-ai-launchpad-user-guide.pdf',
+            loio: undefined,
+            product: 'SAP AI Launchpad'
+          }
+        ]
+      }
+    }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' }
+    })) as any;
+
+    const response = await searchSapHelp('SAP AI Launchpad User Guide');
+
+    expect(response.results[0].id).toMatch(/^sap-help-url-sap-ai-launchpad-user-guide-[a-f0-9]{12}$/);
+    expect(response.results[0].id).not.toBe('sap-help-undefined');
+    expect(response.results[0].url).toBe('https://help.sap.com/doc/sap-ai-launchpad-user-guide.pdf');
+  });
+
+  it('normalizes SAP Community relative, absolute, and fallback URLs', () => {
+    expect(normalizeCommunityUrl('/t5/technology-blogs-by-sap/example/ba-p/123456')).toBe(
+      'https://community.sap.com/t5/technology-blogs-by-sap/example/ba-p/123456'
+    );
+    expect(normalizeCommunityUrl('t5/technology-q-a/example/qaq-p/42')).toBe(
+      'https://community.sap.com/t5/technology-q-a/example/qaq-p/42'
+    );
+    expect(normalizeCommunityUrl(undefined, '987654')).toBe(
+      'https://community.sap.com/t5/forums/messagepage/message-id/987654'
+    );
+  });
+});

--- a/test/source-url-matrix.test.ts
+++ b/test/source-url-matrix.test.ts
@@ -47,6 +47,66 @@ const sourceUrlCases: UrlCase[] = [
     content: copyLoio('dac59fadd5f9419d986f74ba602c6d29', 'Test Recorder'),
     expectedUrl: 'https://ui5.sap.com/#/topic/dac59fadd5f9419d986f74ba602c6d29'
   },
+  {
+    libraryId: '/sapui5',
+    relFile: '01_Whats-New/change-log-a6a78b7.md',
+    content: loio('a6a78b7e104348b4bb94fb8bcf003480', 'Change Log'),
+    expectedUrl: 'https://ui5.sap.com/#/topic/a6a78b7e104348b4bb94fb8bcf003480'
+  },
+  {
+    libraryId: '/sapui5',
+    relFile: '02_Read-Me-First/sapui5-vs-openui5-5982a97.md',
+    content: loio('5982a9734748474aa8d4af9c3d8f31c0', 'SAPUI5 vs. OpenUI5'),
+    expectedUrl: 'https://ui5.sap.com/#/topic/5982a9734748474aa8d4af9c3d8f31c0'
+  },
+  {
+    libraryId: '/sapui5',
+    relFile: '03_Get-Started/quickstart-tutorial-592f36f.md',
+    content: loio('592f36fd077b45349a67dcb3efb46ab1', 'Quickstart Tutorial'),
+    expectedUrl: 'https://ui5.sap.com/#/topic/592f36fd077b45349a67dcb3efb46ab1'
+  },
+  {
+    libraryId: '/sapui5',
+    relFile: '03_Get-Started/navigation-and-routing-tutorial-1b6dcd3.md',
+    content: loio('1b6dcd39a6a74f528b27ddb22f15af0d', 'Navigation and Routing Tutorial'),
+    expectedUrl: 'https://ui5.sap.com/#/topic/1b6dcd39a6a74f528b27ddb22f15af0d'
+  },
+  {
+    libraryId: '/sapui5',
+    relFile: '03_Get-Started/data-binding-tutorial-e531093.md',
+    content: loio('e5310932a71f42daa41f3a6143efca9c', 'Data Binding Tutorial'),
+    expectedUrl: 'https://ui5.sap.com/#/topic/e5310932a71f42daa41f3a6143efca9c'
+  },
+  {
+    libraryId: '/sapui5',
+    relFile: '04_Essentials/routing-and-navigation-3d18f20.md',
+    content: loio('3d18f20bd2294228acb6910d8e8a5fb5', 'Routing and Navigation'),
+    expectedUrl: 'https://ui5.sap.com/#/topic/3d18f20bd2294228acb6910d8e8a5fb5'
+  },
+  {
+    libraryId: '/sapui5',
+    relFile: '04_Essentials/model-view-controller-mvc-91f2334.md',
+    content: loio('91f233476f4d1014b6dd926db0e91070', 'Model View Controller'),
+    expectedUrl: 'https://ui5.sap.com/#/topic/91f233476f4d1014b6dd926db0e91070'
+  },
+  {
+    libraryId: '/sapui5',
+    relFile: '04_Essentials/xml-view-91f2928.md',
+    content: loio('91f292806f4d1014b6dd926db0e91070', 'XML View'),
+    expectedUrl: 'https://ui5.sap.com/#/topic/91f292806f4d1014b6dd926db0e91070'
+  },
+  {
+    libraryId: '/sapui5',
+    relFile: '04_Essentials/binding-syntax-e2e6f41.md',
+    content: loio('e2e6f4127fe4450ab3cf1339c42ee832', 'Binding Syntax'),
+    expectedUrl: 'https://ui5.sap.com/#/topic/e2e6f4127fe4450ab3cf1339c42ee832'
+  },
+  {
+    libraryId: '/sapui5',
+    relFile: '04_Essentials/odata-v4-model-5de13cf.md',
+    content: loio('5de13cf4dd1f4a3480f7e2eaaee3f5b8', 'OData V4 Model'),
+    expectedUrl: 'https://ui5.sap.com/#/topic/5de13cf4dd1f4a3480f7e2eaaee3f5b8'
+  },
 
   // CAP
   {
@@ -105,6 +165,42 @@ const sourceUrlCases: UrlCase[] = [
     content: 'sap.ui.define([]);',
     expectedUrl: 'https://sdk.openui5.org/#/api/sap.ui.core.mvc.Controller'
   },
+  {
+    libraryId: '/openui5-api',
+    relFile: 'sap.m/src/sap/m/Dialog.js',
+    content: 'sap.ui.define([]);',
+    expectedUrl: 'https://sdk.openui5.org/#/api/sap.m.Dialog'
+  },
+  {
+    libraryId: '/openui5-api',
+    relFile: 'sap.m/src/sap/m/Input.js',
+    content: 'sap.ui.define([]);',
+    expectedUrl: 'https://sdk.openui5.org/#/api/sap.m.Input'
+  },
+  {
+    libraryId: '/openui5-api',
+    relFile: 'sap.ui.core/src/sap/ui/core/Component.js',
+    content: 'sap.ui.define([]);',
+    expectedUrl: 'https://sdk.openui5.org/#/api/sap.ui.core.Component'
+  },
+  {
+    libraryId: '/openui5-api',
+    relFile: 'sap.ui.core/src/sap/ui/model/json/JSONModel.js',
+    content: 'sap.ui.define([]);',
+    expectedUrl: 'https://sdk.openui5.org/#/api/sap.ui.model.json.JSONModel'
+  },
+  {
+    libraryId: '/openui5-api',
+    relFile: 'sap.ui.layout/src/sap/ui/layout/form/SimpleForm.js',
+    content: 'sap.ui.define([]);',
+    expectedUrl: 'https://sdk.openui5.org/#/api/sap.ui.layout.form.SimpleForm'
+  },
+  {
+    libraryId: '/openui5-api',
+    relFile: 'sap.uxap/src/sap/uxap/ObjectPageLayout.js',
+    content: 'sap.ui.define([]);',
+    expectedUrl: 'https://sdk.openui5.org/#/api/sap.uxap.ObjectPageLayout'
+  },
 
   // OpenUI5 samples
   {
@@ -142,6 +238,30 @@ const sourceUrlCases: UrlCase[] = [
     relFile: 'sap.uxap/test/sap/uxap/demokit/sample/ObjectPageHeaderExpanded/manifest.json',
     content: '{"sap.app":{"id":"sap.uxap.sample.ObjectPageHeaderExpanded"}}',
     expectedUrl: 'https://sdk.openui5.org/#/entity/sap.uxap.ObjectPageLayout/sample/sap.uxap.sample.ObjectPageHeaderExpanded'
+  },
+  {
+    libraryId: '/openui5-samples',
+    relFile: 'sap.f/test/sap/f/demokit/sample/DynamicPageFreeStyle/manifest.json',
+    content: '{"sap.app":{"id":"sap.f.sample.DynamicPageFreeStyle"}}',
+    expectedUrl: 'https://sdk.openui5.org/#/entity/sap.f.DynamicPage/sample/sap.f.sample.DynamicPageFreeStyle'
+  },
+  {
+    libraryId: '/openui5-samples',
+    relFile: 'sap.ui.layout/test/sap/ui/layout/demokit/sample/SimpleForm354/manifest.json',
+    content: '{"sap.app":{"id":"sap.ui.layout.sample.SimpleForm354"}}',
+    expectedUrl: 'https://sdk.openui5.org/#/entity/sap.ui.layout.form.SimpleForm/sample/sap.ui.layout.sample.SimpleForm354'
+  },
+  {
+    libraryId: '/openui5-samples',
+    relFile: 'sap.ui.core/test/sap/ui/core/demokit/sample/RoutingFullscreen/manifest.json',
+    content: '{"sap.app":{"id":"sap.ui.core.sample.RoutingFullscreen"}}',
+    expectedUrl: 'https://sdk.openui5.org/#/entity/sap.ui.core.routing.Router/sample/sap.ui.core.sample.RoutingFullscreen'
+  },
+  {
+    libraryId: '/openui5-samples',
+    relFile: 'sap.f/test/sap/f/demokit/sample/ShellBar/manifest.json',
+    content: '{"sap.app":{"id":"sap.f.sample.ShellBar"}}',
+    expectedUrl: 'https://sdk.openui5.org/#/entity/sap.f.ShellBar/sample/sap.f.sample.ShellBar'
   },
 
   // wdi5
@@ -513,9 +633,69 @@ const sourceUrlCases: UrlCase[] = [
   },
   {
     libraryId: '/abap-docs-standard',
-    relFile: 'ABAPLOOP.md',
-    content: '# LOOP',
-    expectedUrl: 'https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/ABAPLOOP.html'
+    relFile: 'ABAPLOOP_AT_DBTAB.md',
+    content: '# LOOP AT dbtab',
+    expectedUrl: 'https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/ABAPLOOP_AT_DBTAB.html'
+  },
+  {
+    libraryId: '/abap-docs-standard',
+    relFile: 'ABENABAP.md',
+    content: '# ABAP - Keyword Documentation',
+    expectedUrl: 'https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/ABENABAP.html'
+  },
+  {
+    libraryId: '/abap-docs-standard',
+    relFile: 'ABAPDATA.md',
+    content: '# DATA',
+    expectedUrl: 'https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/ABAPDATA.html'
+  },
+  {
+    libraryId: '/abap-docs-standard',
+    relFile: 'ABAPINSERT_ITAB.md',
+    content: '# INSERT, Internal Tables',
+    expectedUrl: 'https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/ABAPINSERT_ITAB.html'
+  },
+  {
+    libraryId: '/abap-docs-standard',
+    relFile: 'ABAPLOOP_AT_ITAB.md',
+    content: '# LOOP AT itab',
+    expectedUrl: 'https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/ABAPLOOP_AT_ITAB.html'
+  },
+  {
+    libraryId: '/abap-docs-standard',
+    relFile: 'ABAPREAD_TABLE.md',
+    content: '# READ TABLE',
+    expectedUrl: 'https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/ABAPREAD_TABLE.html'
+  },
+  {
+    libraryId: '/abap-docs-standard',
+    relFile: 'ABAPMODIFY_ITAB.md',
+    content: '# MODIFY itab',
+    expectedUrl: 'https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/ABAPMODIFY_ITAB.html'
+  },
+  {
+    libraryId: '/abap-docs-standard',
+    relFile: 'ABAPCLASS.md',
+    content: '# CLASS',
+    expectedUrl: 'https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/ABAPCLASS.html'
+  },
+  {
+    libraryId: '/abap-docs-standard',
+    relFile: 'ABAPMETHODS.md',
+    content: '# METHODS',
+    expectedUrl: 'https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/ABAPMETHODS.html'
+  },
+  {
+    libraryId: '/abap-docs-standard',
+    relFile: 'ABAPCOMMIT.md',
+    content: '# COMMIT WORK',
+    expectedUrl: 'https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/ABAPCOMMIT.html'
+  },
+  {
+    libraryId: '/abap-docs-standard',
+    relFile: 'ABAPTRY.md',
+    content: '# TRY',
+    expectedUrl: 'https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/ABAPTRY.html'
   },
   {
     libraryId: '/abap-docs-cloud',

--- a/test/tools/search-url-verification.js
+++ b/test/tools/search-url-verification.js
@@ -95,7 +95,7 @@ export default [
     skipIfNoResults: true,
     expectIncludes: ['/ui5-tooling/'],
     expectContains: ['🔗'],
-    expectUrlPattern: 'https://sap.github.io/ui5-tooling'
+    expectUrlPattern: 'https://ui5.github.io/cli'
   },
   {
     name: 'Search results should have consistent format with excerpts',


### PR DESCRIPTION
## Goal
Stabilize citation URL generation for every indexed documentation source so search and fetch results return user-citable absolute URLs.

## Changes
- Added source-specific URL generators for GitHub Pages, GitHub blob, MkDocs/Docusaurus-style docs, SAP Help LOIO docs, Terraform Registry, UI5 TypeScript, and UI5 Web Components.
- Fixed SAPUI5 topic URL extraction, including copy-tag topics and index pages, while keeping SAPUI5 on ui5.sap.com and OpenUI5 API/samples on sdk.openui5.org.
- Changed OpenUI5 sample URL generation to read upstream Demokit docuindex.json sample-to-entity metadata instead of maintaining custom namespace prefix mappings.
- Changed CAP URL generation to prefer CAP VitePress menu metadata from menu.md/_menu.md files, with legacy path migrations only for stale already-indexed CAP paths.
- Fixed SAP Help/SAP Community URL normalization and stable SAP Help IDs for non-LOIO results.
- Fixed empty search responses to return valid results: [] payloads instead of MCP schema errors.
- Added exact document lookup/ranking for cases like ABAPSELECT.
- Expanded source indexing and variant coverage for citation QA gaps.
- Added regression tests with at least three URL cases per configured source plus SAP Help and SAP Community normalization checks.
- Expanded citation coverage with 10 additional SAPUI5 topic links, 10 additional OpenUI5 API/sample links, and 10 representative ABAP standard keyword documentation links back to official SAP Help.

## Validation
- npm run test:url-generation
- git diff --check
- Spot-checked representative public URLs with curl: SAPUI5 ui5.sap.com topic routes, OpenUI5 sdk.openui5.org API/sample routes, and ABAP Help .html pages all returned HTTP 200 at the public host.
- Streamable MCP server restarted locally and health checked at http://127.0.0.1:3122/health

## Notes
- Local .claude/ worktree files and dirty submodule worktrees were intentionally left out of this PR.
- CAP local submodule was observed to be older than cap-js/docs main; setup.sh updates active submodules to branch heads, so the generator now handles both current CAP paths and stale indexed paths.
- ABAP keyword documentation source metadata and the abap-docs manifest both point back to help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/ for Standard ABAP and help.sap.com/doc/abapdocu_cp_index_htm/CLOUD/en-US/ for ABAP Cloud.