### PR TITLE
fix(http): graceful stateless fallback for stale Mcp-Session-Id

### DIFF
--- a/src/streamable-http-server.ts
+++ b/src/streamable-http-server.ts
@@ -157,8 +157,14 @@ async function main() {
           method: req.method,
           transportCount: Object.keys(transports).length
         });
-      } else if (!sessionId && req.method === 'POST' && req.is('application/json') && req.body?.method === 'initialize') {
-        // New initialization request - create new transport
+      } else if (req.method === 'POST' && req.is('application/json') && req.body?.method === 'initialize') {
+        // Initialization request — create a fresh transport.
+        //
+        // We also enter this branch if `sessionId` is present but doesn't match
+        // any live transport (server restarted, session cleaned up via
+        // `onsessionclosed`, in-memory map wiped). Per MCP spec the client is
+        // permitted to re-send `initialize` to recover; the server generates a
+        // new Mcp-Session-Id and the client should adopt it.
         const cleanupTransport = (
           sessionId: string | undefined,
           trigger: "onsessionclosed" | "onclose",
@@ -211,12 +217,21 @@ async function main() {
           requestId,
           method: req.method
         });
-      } else if (!sessionId && req.method === 'POST' && req.is('application/json')) {
-        // Stateless request (no session ID, not initialize) — create one-shot transport
-        // This supports clients like Joule Studio that don't maintain sessions
-        logger.debug('Stateless MCP request, creating one-shot transport', {
+      } else if (req.method === 'POST' && req.is('application/json')) {
+        // Stateless one-shot transport. Reached in two cases:
+        //   1. No session ID (clients like Joule Studio that don't maintain sessions).
+        //   2. Session ID present but unknown to the server (stale session — server
+        //      restarted, container redeployed, or session was cleaned up). Without
+        //      this fallback the client gets a hard HTTP 400 and many MCP clients
+        //      (notably Cursor) won't auto-recover by re-initializing, so the user
+        //      sees "No valid session ID" errors until they manually reconnect the
+        //      MCP. Treating stale sessions as one-shot trades a tiny amount of
+        //      per-session state for restart resilience — appropriate for a public,
+        //      read-only docs/search server.
+        logger.debug('Stateless / stale-session MCP request — creating one-shot transport', {
           requestId,
           bodyMethod: req.body?.method,
+          hasStaleSessionId: Boolean(sessionId),
           userAgent: req.headers['user-agent']
         });
 
@@ -227,12 +242,15 @@ async function main() {
         const server = createServer();
         await server.connect(transport);
       } else {
-        // Invalid request - no session ID or not initialization request
+        // Invalid request — only non-POST or non-JSON requests reach this branch
+        // after the stateless-fallback above. Typical case: GET/DELETE /mcp
+        // without a live session (the MCP spec uses POST for the actual JSON-RPC
+        // traffic; GET/DELETE are only valid on an already-initialized stream).
         logger.warn('Invalid MCP request', {
           requestId,
           method: req.method,
           hasSessionId: !!sessionId,
-          isInitRequest: req.method === 'POST' && req.is('application/json') && req.body?.method === 'initialize',
+          contentType: req.headers['content-type'] || 'none',
           sessionId: sessionId || 'none',
           userAgent: req.headers['user-agent']
         });
@@ -241,7 +259,7 @@ async function main() {
           jsonrpc: '2.0',
           error: {
             code: -32000,
-            message: 'Bad Request: No valid session ID provided or not an initialization request',
+            message: 'Bad Request: MCP requests must be POST with application/json (or GET/DELETE on a live session).',
           },
           id: null,
         });


### PR DESCRIPTION
## Summary

The streamable HTTP transport returns `HTTP 400 "Bad Request: No valid session ID provided or not an initialization request"` whenever it receives a request whose `Mcp-Session-Id` header doesn't match a live transport. This happens routinely:

- Server / container restart wipes the in-memory `transports[]` map (line 111 of `src/streamable-http-server.ts`).
- `onsessionclosed` cleans up after legitimate teardown (browser tab close, network blip).
- Cursor (and most MCP clients) pin the session ID they received on `initialize` and don't auto-recover when the server forgets them.

End-user impact: MCPs go dead for the rest of a Cursor chat (or until the user manually toggles the MCP off/on). The error is opaque — looks like a server bug, not a "your session expired" hint.

## Reproduction (against current prod)

```bash
# WITHOUT session ID — existing stateless branch (lines 214-228). Always worked.
curl -i -X POST https://mcp-sap-docs.marianzeis.de/mcp \
  -H 'Content-Type: application/json' \
  -H 'Accept: application/json, text/event-stream' \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
# → HTTP/2 200, SSE body with the tool list

# WITH stale session ID — falls through to branch 4 (400).
curl -i -X POST https://mcp-sap-docs.marianzeis.de/mcp \
  -H 'Content-Type: application/json' \
  -H 'Accept: application/json, text/event-stream' \
  -H 'Mcp-Session-Id: bogus-stale-12345' \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
# → HTTP/2 400
# → {"jsonrpc":"2.0","error":{"code":-32000,
#      "message":"Bad Request: No valid session ID provided or not an initialization request"},
#      "id":null}
```

After this PR, the stale-session request returns the same `HTTP 200 + SSE` as the no-session request.

## Root cause

The routing block in `app.all('/mcp', ...)` has four branches:

| # | Condition | Outcome |
|---|---|---|
| 1 | `sessionId && transports[sessionId]` | ✓ reuse live transport |
| 2 | `!sessionId && POST + JSON + method==='initialize'` | ✓ create new session |
| 3 | `!sessionId && POST + JSON` | ✓ stateless one-shot |
| 4 | else | ✗ HTTP 400 |

A request with a **stale** session ID has `sessionId` truthy but `transports[sessionId]` falsy → fails branch 1, can't enter branches 2 or 3 (both gated on `!sessionId`) → branch 4.

## Fix

Drop the `!sessionId` guard from branches 2 and 3. Both can now also recover stale sessions. Also tightens the branch-4 error message — only non-POST / non-JSON requests reach it now, so the old "no valid session ID" wording is misleading.

Behavior matrix after the fix:

| sessionId | method | body.method | Branch | Result |
|---|---|---|---|---|
| live | any | any | 1 | Reuse transport |
| missing | POST + JSON | `initialize` | 2 | New session |
| **stale** | POST + JSON | `initialize` | **2** | **New session (re-init recovery)** |
| missing | POST + JSON | other | 3 | Stateless one-shot |
| **stale** | POST + JSON | other | **3** | **Stateless one-shot (recovery)** |
| any | GET / DELETE / non-JSON | any | 4 | 400 with the clearer message |

## Trade-off

Trades a tiny amount of per-session state for restart resilience. Appropriate for a public, read-only docs/search server with no per-session cached state that could leak across users. If per-session privacy ever becomes a concern, the stale-session branch should be revisited (e.g. return `-32001 "session not found, please re-initialize"` instead of silently serving statelessly).

## Verification

- `npm run build:tsc` — clean
- `dist/src/streamable-http-server.js` reflects the new branches (verified via `grep`)
- Local runtime smoke against the built dist was blocked on this machine by a `sharp` native-module install issue (unrelated to this fix); the PROD-side `curl` reproductions above are the authoritative repro.

## Test plan

- [x] Typecheck passes
- [x] Compiled output contains the new branches
- [x] Live PROD reproduces the 400 today (curl above)
- [ ] Live PROD returns 200 after this deploys (rerun the same `curl` after merge)
- [ ] Optional follow-up: vitest integration test asserting the four routing branches. Requires either exposing the route handler as an exported function or installing `supertest`. Happy to do in a separate PR.

## Related

Surfaced during a SEGW→RAP→Fiori Elements migration session ("Run 7") where Cursor was using `sap-docs` mid-conversation as a reference lookup and hit this exact error. Toggling the MCP off/on in Cursor's settings was the manual workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
