### PR TITLE
feat: load ui5 diffs from local bundle

### DIFF
--- a/.claude/skills/ui5-version-upgrade/SKILL.md
+++ b/.claude/skills/ui5-version-upgrade/SKILL.md
@@ -1,118 +1,138 @@
 ---
 name: ui5-version-upgrade
-description: Plan and execute a SAPUI5/OpenUI5 version upgrade. Use when the user is bumping the UI5 version in manifest.json / ui5.yaml and wants to know which deprecated APIs they still use, which workarounds can be dropped, and which fixes already shipped. Combines this server's `ui5_version_diff` tool with the SAP `@ui5/mcp-server` tools (`run_ui5_linter`, `run_manifest_validation`, `get_api_reference`, `get_project_info`, `get_version_info`).
+description: Plan and execute a SAPUI5/OpenUI5 version upgrade. Use when the user is bumping the UI5 version in manifest.json, ui5.yaml, package.json, or an existing UI5 app and wants to identify deprecations in use, fixes that remove local workarounds, relevant new features, manifest/schema issues, and API replacements. Combines this server's `ui5_version_diff` tool with SAP's `@ui5/mcp-server` tools.
 ---
 
 # UI5 Version Upgrade
 
-A migration-assist workflow for SAPUI5/OpenUI5 projects. Two MCP servers cooperate here:
+A migration workflow for SAPUI5/OpenUI5 projects. Use two MCP servers together:
 
-- **This server** (`mcp-sap-docs`) provides `ui5_version_diff`: lists FEATURE / FIX / DEPRECATED changes between two UI5 releases from [ui5-lib-diff](https://github.com/marianfoo/ui5-lib-diff).
-- **`@ui5/mcp-server`** (separate, by SAP, runs locally per project) provides code-level tools: `run_ui5_linter`, `run_manifest_validation`, `get_api_reference`, `get_project_info`, `get_version_info`, etc.
+- **`mcp-sap-docs`** provides `ui5_version_diff`, backed by a local ui5-lib-diff all-changes JSON bundle. It answers "what changed between versions?"
+- **SAP `@ui5/mcp-server`** runs against the local project. It answers "what does this app use and what is broken?"
 
-The skill expects both to be configured. If `@ui5/mcp-server` is not available, fall back to manual code-grep for the code-level steps and tell the user which tool would have helped.
+Do not scrape the ui5-lib-diff browser route for JSON. The browser URL with `versionFrom`, `versionTo`, and `ui5Type` is client-rendered. Use `ui5_version_diff`; it reads the local `all-changes.json` bundle and returns a small structured result. `npm run setup` refreshes the bundle automatically; if it is missing, run `npm run download:ui5-lib-diff` in the MCP server repo or point `UI5_LIB_DIFF_BUNDLE_PATH` to a local copy.
 
-## When to use
+## UI5 MCP tools to use
 
-Trigger this skill when the user says any of:
+Current SAP `@ui5/mcp-server` capabilities include:
 
-- "I'm upgrading from UI5 X.Y to X.Z, what do I need to fix?"
-- "What's deprecated between 1.108 and 1.130?"
-- "Can I drop this workaround now that we're on 1.130?"
-- "Migrate the manifest to UI5 1.x"
-- "Audit our UI5 code for deprecations"
+- `get_project_info`: read project metadata and UI5 configuration.
+- `get_version_info`: retrieve UI5 framework version information.
+- `get_guidelines`: fetch UI5 coding standards and best practices.
+- `get_api_reference`: fetch UI5 API documentation for controls/classes/methods.
+- `run_ui5_linter`: run `@ui5/linter` against the app.
+- `run_manifest_validation`: validate `webapp/manifest.json`.
+- `get_typescript_conversion_guidelines`: guidance for JavaScript-to-TypeScript UI5 work.
+- `create_ui5_app`, `create_integration_card`, `get_integration_cards_guidelines`: scaffolding/card-specific work. Use only when the user asks for creation or card work.
 
-## Inputs to gather first
+## Inputs
 
-Before running anything, get:
+Determine these before producing recommendations:
 
-1. **Project root** — needed by `@ui5/mcp-server` tools that operate per-project.
-2. **`from_version`** — current UI5 version. Read it from the project. If `@ui5/mcp-server` is available, call `get_project_info` / `get_version_info`. Otherwise read `webapp/manifest.json` (`sap.platform.cf.ui5VersionNumber` or `sap.ui5.dependencies.minUI5Version`) or `ui5.yaml` / `package.json` (`@sapui5/distribution-metadata`, `@openui5/...`).
-3. **`to_version`** — the version the user wants to move to. If unsure, suggest the latest LTS minor available in `versionsInRange` after a probe call.
-4. **`library`** — "SAPUI5" if commercial libs (`sap.suite.*`, `sap.ui.comp`, `sap.fe`, `sap.ui.mdc`) are present; "OpenUI5" otherwise.
+1. **Project root**: required for UI5 MCP project tools.
+2. **Current version** (`from_version`): prefer `get_project_info` / `get_version_info`; otherwise read `webapp/manifest.json`, `ui5.yaml`, and `package.json`.
+3. **Target version** (`to_version`): ask if absent. Use the full `x.y.z` form.
+4. **Library flavor**: use `SAPUI5` if the app depends on commercial libraries such as `sap.ui.comp`, `sap.suite.*`, `sap.fe`, `sap.ui.mdc`, or FLP/ushell; otherwise use `OpenUI5`.
+5. **Declared UI5 libraries**: read `sap.ui5.dependencies.libs` and use them to focus feature/fix review.
 
 ## Workflow
 
-### 1. Establish the upgrade scope
+### 1. Establish scope
+
+Call:
 
 ```text
-ui5_version_diff(library, from_version, to_version)            # full picture (counts)
+ui5_version_diff(library, from_version, to_version)
 ```
 
-Read `counts` and `versionsInRange`. Print a one-paragraph summary:
-"Upgrading $library from $from to $to covers N versions, with F features, X fixes, D deprecations."
+Summarize `versionsInRange`, `counts`, `totalEntries`, and any `meta.notes`. Keep `meta.sourceDataPath` for traceability.
 
-### 2. List deprecations and map them to code
+### 2. Get project facts
+
+Call:
+
+```text
+get_project_info(projectPath=<project root>)
+get_version_info(projectPath=<project root>)
+get_guidelines()
+```
+
+Use `get_guidelines` once per workflow to anchor coding recommendations. Do not repeatedly fetch broad guidelines inside loops.
+
+### 3. Find deprecations actually used
+
+Call:
 
 ```text
 ui5_version_diff(library, from_version, to_version, types=["DEPRECATED"], limit=1000)
+run_ui5_linter(projectPath=<project root>)
 ```
 
-For each deprecation entry, the `text` typically starts with `[sap.x.y.Control#method]` or names a control. For each one:
+Cross-reference diff deprecations with linter findings and code search. Report only confirmed or strongly suspected usage in the app. Skip deprecations that do not match the project.
 
-- If `@ui5/mcp-server` is available: call `run_ui5_linter` on the project. The linter already flags deprecated API usage; cross-reference its findings with the diff entries to know **which deprecations actually affect this project**. Do not list every deprecation — only the ones the linter confirms are in use.
-- Otherwise, grep the project (`webapp/**/*.{js,ts,xml,json}`) for the control / API names from the entries and report a confirmed-use list.
-
-For each confirmed-in-use deprecation, fetch the replacement details:
+For confirmed APIs, call:
 
 ```text
-get_api_reference(name=<the replacement API mentioned in the deprecation text>)
+get_api_reference(name=<control/class/method>)
 ```
 
-Produce a table: deprecated API → replacement → file:line where used.
+Use this for replacement details. Do not invent replacements from memory.
 
-### 3. Find workarounds that can be dropped
+### 4. Find removable workarounds
 
-Ask the user which symptoms / bug numbers / phrases their codebase still works around (look in comments: `TODO`, `FIXME`, `workaround`, `BCP`, internal ticket IDs). For each candidate:
+Search project comments and code for `TODO`, `FIXME`, `workaround`, BCP/ticket IDs, and symptom words. For each meaningful symptom:
 
 ```text
-ui5_version_diff(library, from_version, to_version, types=["FIX"], query=<symptom keyword>)
+ui5_version_diff(library, from_version, to_version, types=["FIX"], query=<symptom>)
 ```
 
-If `entries.length > 0`, the workaround can likely be removed. Cite the commit URL from the entry so the user can review the actual fix.
+If there is a matching fix, cite the entry and commit URL, then verify whether the local workaround can be removed safely.
 
-### 4. Surface relevant new features
+### 5. Surface relevant features
+
+For each declared UI5 library:
 
 ```text
-ui5_version_diff(library, from_version, to_version, types=["FEATURE"], ui5_library=<each lib the project depends on>)
+ui5_version_diff(library, from_version, to_version, types=["FEATURE"], ui5_library=<declared lib>, limit=50)
 ```
 
-Iterate over the project's declared dependencies (from `manifest.json` → `sap.ui5.dependencies.libs`). Keep the list focused on libs the project actually uses — don't dump every new feature in every library.
+Keep this selective. Mention features that plausibly affect the app's libraries or current code, not every framework feature.
 
-### 5. Validate the manifest for the target version
+### 6. Validate manifest and rerun after edits
+
+Call:
 
 ```text
-run_manifest_validation(manifestPath=<project>/webapp/manifest.json)
+run_manifest_validation(manifestPath=<project root>/webapp/manifest.json)
+run_ui5_linter(projectPath=<project root>)
 ```
 
-Report any schema violations that the new version surfaces.
+After making fixes, rerun the linter and manifest validation. Treat these tool results as stronger evidence than general release-note text.
 
-### 6. Re-lint after changes
+## Output
 
-When the user has applied fixes, run `run_ui5_linter` again to verify the deprecation count dropped.
+Default to one concise Markdown report:
 
-## Output format
+1. **Scope**: flavor, from/to, versions covered, counts, source data path.
+2. **Required fixes**: deprecated API, replacement, file:line, evidence.
+3. **Workarounds to remove**: local workaround, matching UI5 fix, commit URL.
+4. **Relevant features**: grouped by used UI5 library.
+5. **Manifest and linter status**: pass/fail with actionable details.
+6. **Edit plan**: concrete changes in order.
 
-Default to a single Markdown report with these sections, in this order:
+Keep raw diff output out of the report. If `truncated` is true, narrow with `ui5_library` or `query`.
 
-1. **Scope** — library, from → to, counts, versions covered
-2. **Deprecations to address** — table of (API, replacement, file:line, commit_url)
-3. **Workarounds that can be removed** — list with the commit_url that proves the fix shipped
-4. **New features worth adopting** — bulleted per library, only the ones relevant to declared deps
-5. **Manifest validation results** — pass/fail with details
-6. **Next steps** — concrete edits to make, in order
+## Guardrails
 
-Keep entries terse. Link to commits, don't paste them. If `ui5_version_diff` returns `truncated: true` for any call, mention that and offer to drill down by `ui5_library` or `query`.
+- Use exact `x.y.z` versions. `1.120` equals `1.120.0` and can miss patch releases such as `1.120.5`.
+- `from_version` must be strictly less than `to_version`; the range is `(from_version, to_version]`.
+- Do not run scaffolding tools (`create_ui5_app`, `create_integration_card`) unless the user requested creation.
+- Do not run project-local UI5 MCP tools without a real project path.
+- Do not present every deprecation as required work. The app must use it, or the linter/code search must make it relevant.
+- Prefer structured tool results and small filtered calls over passing large intermediate lists through the model.
 
-## Constraints
+## Fallbacks
 
-- **Do not paste full `ui5_version_diff` results into the report** — they are long. Summarize counts, then list only project-relevant entries.
-- **Do not invent deprecations.** Only list what `ui5_version_diff` actually returned for the given range.
-- **Never call `@ui5/mcp-server` tools speculatively** — always pass a real project path you obtained from the user or detected on disk.
-- The `@ui5/mcp-server` tool is `run_ui5_linter` (note the `_linter` suffix), not `run_ui5_lint`.
-
-## Failure modes
-
-- `ui5_version_diff` returns `from_version must be <= to_version`: swap the order or ask the user.
-- `@ui5/mcp-server` is not installed: tell the user how to add it (`npm i -D @ui5/mcp-server`) and proceed with degraded coverage (no linter cross-reference, no manifest validation, no API reference lookup).
-- A deprecation mentions an API the user doesn't seem to use: skip silently — the goal is signal, not exhaustiveness.
+- If SAP `@ui5/mcp-server` is unavailable, proceed with degraded coverage: use `ui5_version_diff`, local file inspection, and `rg` across `webapp/**/*.{js,ts,xml,json}`. Tell the user which UI5 MCP checks were skipped.
+- If `ui5_version_diff` reports that the local bundle is missing, run `npm run download:ui5-lib-diff` in the MCP server repo or point `UI5_LIB_DIFF_BUNDLE_PATH` to a local copy.
+- If no versions match, check version spelling and patch-level availability before concluding that there were no changes.

--- a/.claude/skills/ui5-version-upgrade/SKILL.md
+++ b/.claude/skills/ui5-version-upgrade/SKILL.md
@@ -7,7 +7,7 @@ description: Plan and execute a SAPUI5/OpenUI5 version upgrade. Use when the use
 
 A migration workflow for SAPUI5/OpenUI5 projects. Use two MCP servers together:
 
-- **`mcp-sap-docs`** provides `ui5_version_diff`, backed by a local ui5-lib-diff all-changes JSON bundle. It answers "what changed between versions?"
+- **`mcp-sap-docs`** provides `ui5_version_diff`, backed by a local ui5-lib-diff all-changes JSON bundle. It answers "what changed between versions?" and includes SAPUI5 What's New entries for the same range.
 - **SAP `@ui5/mcp-server`** runs against the local project. It answers "what does this app use and what is broken?"
 
 Do not scrape the ui5-lib-diff browser route for JSON. The browser URL with `versionFrom`, `versionTo`, and `ui5Type` is client-rendered. Use `ui5_version_diff`; it reads the local `all-changes.json` bundle and returns a small structured result. `npm run setup` refreshes the bundle automatically; if it is missing, run `npm run download:ui5-lib-diff` in the MCP server repo or point `UI5_LIB_DIFF_BUNDLE_PATH` to a local copy.
@@ -45,7 +45,7 @@ Call:
 ui5_version_diff(library, from_version, to_version)
 ```
 
-Summarize `versionsInRange`, `counts`, `totalEntries`, and any `meta.notes`. Keep `meta.sourceDataPath` for traceability.
+Summarize `versionsInRange`, `counts`, `totalEntries`, `whatsNewTotalEntries`, and any `meta.notes`. Keep `meta.sourceDataPath` for traceability. If the user asks about one release, call `ui5_version_diff(library, version=<x.y.z>)`.
 
 ### 2. Get project facts
 
@@ -113,10 +113,10 @@ After making fixes, rerun the linter and manifest validation. Treat these tool r
 
 Default to one concise Markdown report:
 
-1. **Scope**: flavor, from/to, versions covered, counts, source data path.
+1. **Scope**: flavor, from/to or single version, versions covered, counts, What's New count, source data path.
 2. **Required fixes**: deprecated API, replacement, file:line, evidence.
 3. **Workarounds to remove**: local workaround, matching UI5 fix, commit URL.
-4. **Relevant features**: grouped by used UI5 library.
+4. **Relevant features and What's New**: grouped by used UI5 library or product area.
 5. **Manifest and linter status**: pass/fail with actionable details.
 6. **Edit plan**: concrete changes in order.
 
@@ -124,8 +124,8 @@ Keep raw diff output out of the report. If `truncated` is true, narrow with `ui5
 
 ## Guardrails
 
-- Use exact `x.y.z` versions. `1.120` equals `1.120.0` and can miss patch releases such as `1.120.5`.
-- `from_version` must be strictly less than `to_version`; the range is `(from_version, to_version]`.
+- Prefer exact `x.y.z` versions. If a requested patch is unavailable, `ui5_version_diff` resolves it to the nearest lower available patch with the same major.minor, matching the ui5-lib-diff web app.
+- For ranges, use `(from_version, to_version]`. For one release, use `version=<x.y.z>` or pass only one version field.
 - Do not run scaffolding tools (`create_ui5_app`, `create_integration_card`) unless the user requested creation.
 - Do not run project-local UI5 MCP tools without a real project path.
 - Do not present every deprecation as required work. The app must use it, or the linter/code search must make it relevant.

--- a/.claude/skills/ui5-version-upgrade/SKILL.md
+++ b/.claude/skills/ui5-version-upgrade/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: ui5-version-upgrade
+description: Plan and execute a SAPUI5/OpenUI5 version upgrade. Use when the user is bumping the UI5 version in manifest.json / ui5.yaml and wants to know which deprecated APIs they still use, which workarounds can be dropped, and which fixes already shipped. Combines this server's `ui5_version_diff` tool with the SAP `@ui5/mcp-server` tools (`run_ui5_linter`, `run_manifest_validation`, `get_api_reference`, `get_project_info`, `get_version_info`).
+---
+
+# UI5 Version Upgrade
+
+A migration-assist workflow for SAPUI5/OpenUI5 projects. Two MCP servers cooperate here:
+
+- **This server** (`mcp-sap-docs`) provides `ui5_version_diff`: lists FEATURE / FIX / DEPRECATED changes between two UI5 releases from [ui5-lib-diff](https://github.com/marianfoo/ui5-lib-diff).
+- **`@ui5/mcp-server`** (separate, by SAP, runs locally per project) provides code-level tools: `run_ui5_linter`, `run_manifest_validation`, `get_api_reference`, `get_project_info`, `get_version_info`, etc.
+
+The skill expects both to be configured. If `@ui5/mcp-server` is not available, fall back to manual code-grep for the code-level steps and tell the user which tool would have helped.
+
+## When to use
+
+Trigger this skill when the user says any of:
+
+- "I'm upgrading from UI5 X.Y to X.Z, what do I need to fix?"
+- "What's deprecated between 1.108 and 1.130?"
+- "Can I drop this workaround now that we're on 1.130?"
+- "Migrate the manifest to UI5 1.x"
+- "Audit our UI5 code for deprecations"
+
+## Inputs to gather first
+
+Before running anything, get:
+
+1. **Project root** — needed by `@ui5/mcp-server` tools that operate per-project.
+2. **`from_version`** — current UI5 version. Read it from the project. If `@ui5/mcp-server` is available, call `get_project_info` / `get_version_info`. Otherwise read `webapp/manifest.json` (`sap.platform.cf.ui5VersionNumber` or `sap.ui5.dependencies.minUI5Version`) or `ui5.yaml` / `package.json` (`@sapui5/distribution-metadata`, `@openui5/...`).
+3. **`to_version`** — the version the user wants to move to. If unsure, suggest the latest LTS minor available in `versionsInRange` after a probe call.
+4. **`library`** — "SAPUI5" if commercial libs (`sap.suite.*`, `sap.ui.comp`, `sap.fe`, `sap.ui.mdc`) are present; "OpenUI5" otherwise.
+
+## Workflow
+
+### 1. Establish the upgrade scope
+
+```text
+ui5_version_diff(library, from_version, to_version)            # full picture (counts)
+```
+
+Read `counts` and `versionsInRange`. Print a one-paragraph summary:
+"Upgrading $library from $from to $to covers N versions, with F features, X fixes, D deprecations."
+
+### 2. List deprecations and map them to code
+
+```text
+ui5_version_diff(library, from_version, to_version, types=["DEPRECATED"], limit=1000)
+```
+
+For each deprecation entry, the `text` typically starts with `[sap.x.y.Control#method]` or names a control. For each one:
+
+- If `@ui5/mcp-server` is available: call `run_ui5_linter` on the project. The linter already flags deprecated API usage; cross-reference its findings with the diff entries to know **which deprecations actually affect this project**. Do not list every deprecation — only the ones the linter confirms are in use.
+- Otherwise, grep the project (`webapp/**/*.{js,ts,xml,json}`) for the control / API names from the entries and report a confirmed-use list.
+
+For each confirmed-in-use deprecation, fetch the replacement details:
+
+```text
+get_api_reference(name=<the replacement API mentioned in the deprecation text>)
+```
+
+Produce a table: deprecated API → replacement → file:line where used.
+
+### 3. Find workarounds that can be dropped
+
+Ask the user which symptoms / bug numbers / phrases their codebase still works around (look in comments: `TODO`, `FIXME`, `workaround`, `BCP`, internal ticket IDs). For each candidate:
+
+```text
+ui5_version_diff(library, from_version, to_version, types=["FIX"], query=<symptom keyword>)
+```
+
+If `entries.length > 0`, the workaround can likely be removed. Cite the commit URL from the entry so the user can review the actual fix.
+
+### 4. Surface relevant new features
+
+```text
+ui5_version_diff(library, from_version, to_version, types=["FEATURE"], ui5_library=<each lib the project depends on>)
+```
+
+Iterate over the project's declared dependencies (from `manifest.json` → `sap.ui5.dependencies.libs`). Keep the list focused on libs the project actually uses — don't dump every new feature in every library.
+
+### 5. Validate the manifest for the target version
+
+```text
+run_manifest_validation(manifestPath=<project>/webapp/manifest.json)
+```
+
+Report any schema violations that the new version surfaces.
+
+### 6. Re-lint after changes
+
+When the user has applied fixes, run `run_ui5_linter` again to verify the deprecation count dropped.
+
+## Output format
+
+Default to a single Markdown report with these sections, in this order:
+
+1. **Scope** — library, from → to, counts, versions covered
+2. **Deprecations to address** — table of (API, replacement, file:line, commit_url)
+3. **Workarounds that can be removed** — list with the commit_url that proves the fix shipped
+4. **New features worth adopting** — bulleted per library, only the ones relevant to declared deps
+5. **Manifest validation results** — pass/fail with details
+6. **Next steps** — concrete edits to make, in order
+
+Keep entries terse. Link to commits, don't paste them. If `ui5_version_diff` returns `truncated: true` for any call, mention that and offer to drill down by `ui5_library` or `query`.
+
+## Constraints
+
+- **Do not paste full `ui5_version_diff` results into the report** — they are long. Summarize counts, then list only project-relevant entries.
+- **Do not invent deprecations.** Only list what `ui5_version_diff` actually returned for the given range.
+- **Never call `@ui5/mcp-server` tools speculatively** — always pass a real project path you obtained from the user or detected on disk.
+- The `@ui5/mcp-server` tool is `run_ui5_linter` (note the `_linter` suffix), not `run_ui5_lint`.
+
+## Failure modes
+
+- `ui5_version_diff` returns `from_version must be <= to_version`: swap the order or ask the user.
+- `@ui5/mcp-server` is not installed: tell the user how to add it (`npm i -D @ui5/mcp-server`) and proceed with degraded coverage (no linter cross-reference, no manifest validation, no API reference lookup).
+- A deprecation mentions an API the user doesn't seem to use: skip silently — the goal is signal, not exhaustiveness.

--- a/.claude/skills/ui5-version-upgrade/SKILL.md
+++ b/.claude/skills/ui5-version-upgrade/SKILL.md
@@ -10,7 +10,7 @@ A migration workflow for SAPUI5/OpenUI5 projects. Use two MCP servers together:
 - **`mcp-sap-docs`** provides `ui5_version_diff`, backed by a local ui5-lib-diff all-changes JSON bundle. It answers "what changed between versions?" and includes SAPUI5 What's New entries for the same range.
 - **SAP `@ui5/mcp-server`** runs against the local project. It answers "what does this app use and what is broken?"
 
-Do not scrape the ui5-lib-diff browser route for JSON. The browser URL with `versionFrom`, `versionTo`, and `ui5Type` is client-rendered. Use `ui5_version_diff`; it reads the local `all-changes.json` bundle and returns a small structured result. `npm run setup` refreshes the bundle automatically; if it is missing, run `npm run download:ui5-lib-diff` in the MCP server repo or point `UI5_LIB_DIFF_BUNDLE_PATH` to a local copy.
+Do not scrape the ui5-lib-diff browser route for JSON. The browser URL with `versionFrom`, `versionTo`, and `ui5Type` is client-rendered. Use `ui5_version_diff`; it reads the local `all-changes.json` bundle and returns all matching structured entries. `npm run setup` refreshes the bundle automatically; if it is missing or stale, refresh it during setup/rebuild with `npm run download:ui5-lib-diff` or point `UI5_LIB_DIFF_BUNDLE_PATH` to a local copy. The runtime is local-only and must not rely on external requests.
 
 ## UI5 MCP tools to use
 
@@ -45,7 +45,7 @@ Call:
 ui5_version_diff(library, from_version, to_version)
 ```
 
-Summarize `versionsInRange`, `counts`, `totalEntries`, `whatsNewTotalEntries`, and any `meta.notes`. Keep `meta.sourceDataPath` for traceability. If the user asks about one release, call `ui5_version_diff(library, version=<x.y.z>)`.
+Summarize `versionsInRange`, `counts`, `totalEntries`, `whatsNewTotalEntries`, and any `meta.notes`. Keep `meta.sourceDataPath` and `meta.generatedAt` for traceability and stale-bundle checks. If the user asks about one release, call `ui5_version_diff(library, version=<x.y.z>)`.
 
 ### 2. Get project facts
 
@@ -64,7 +64,7 @@ Use `get_guidelines` once per workflow to anchor coding recommendations. Do not 
 Call:
 
 ```text
-ui5_version_diff(library, from_version, to_version, types=["DEPRECATED"], limit=1000)
+ui5_version_diff(library, from_version, to_version, types=["DEPRECATED"])
 run_ui5_linter(projectPath=<project root>)
 ```
 
@@ -93,7 +93,7 @@ If there is a matching fix, cite the entry and commit URL, then verify whether t
 For each declared UI5 library:
 
 ```text
-ui5_version_diff(library, from_version, to_version, types=["FEATURE"], ui5_library=<declared lib>, limit=50)
+ui5_version_diff(library, from_version, to_version, types=["FEATURE"], ui5_library=<declared lib>)
 ```
 
 Keep this selective. Mention features that plausibly affect the app's libraries or current code, not every framework feature.
@@ -120,19 +120,20 @@ Default to one concise Markdown report:
 5. **Manifest and linter status**: pass/fail with actionable details.
 6. **Edit plan**: concrete changes in order.
 
-Keep raw diff output out of the report. If `truncated` is true, narrow with `ui5_library` or `query`.
+Keep raw diff output out of the report. The tool returns all matching entries; if the result is broad, make narrower follow-up calls with `types`, `ui5_library`, or `query`.
 
 ## Guardrails
 
 - Prefer exact `x.y.z` versions. If a requested patch is unavailable, `ui5_version_diff` resolves it to the nearest lower available patch with the same major.minor, matching the ui5-lib-diff web app.
 - For ranges, use `(from_version, to_version]`. For one release, use `version=<x.y.z>` or pass only one version field.
+- If `meta.notes` says the requested release is newer than the local bundle, do not attempt runtime web fetches. Tell the user the setup-time bundle is stale and should be refreshed before relying on that release.
 - Do not run scaffolding tools (`create_ui5_app`, `create_integration_card`) unless the user requested creation.
 - Do not run project-local UI5 MCP tools without a real project path.
 - Do not present every deprecation as required work. The app must use it, or the linter/code search must make it relevant.
-- Prefer structured tool results and small filtered calls over passing large intermediate lists through the model.
+- Prefer structured tool results and targeted filtered calls over passing broad intermediate lists through the model.
 
 ## Fallbacks
 
 - If SAP `@ui5/mcp-server` is unavailable, proceed with degraded coverage: use `ui5_version_diff`, local file inspection, and `rg` across `webapp/**/*.{js,ts,xml,json}`. Tell the user which UI5 MCP checks were skipped.
-- If `ui5_version_diff` reports that the local bundle is missing, run `npm run download:ui5-lib-diff` in the MCP server repo or point `UI5_LIB_DIFF_BUNDLE_PATH` to a local copy.
+- If `ui5_version_diff` reports that the local bundle is missing or stale, refresh the bundle during setup/rebuild with `npm run download:ui5-lib-diff` in the MCP server repo or point `UI5_LIB_DIFF_BUNDLE_PATH` to a local copy.
 - If no versions match, check version spelling and patch-level availability before concluding that there were no changes.

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,6 +83,18 @@ RUN printf '%s\n' "${MCP_VARIANT}" > .mcp-variant && \
       fi; \
     done
 
+# Download setup-time auxiliary datasets for variant-enabled tools. The
+# ui5_version_diff runtime reads only the local bundle produced here.
+RUN UI5_LIB_DIFF_ENABLED="$(node --input-type=module -e ' \
+      import fs from "node:fs"; \
+      const variant = (process.env.MCP_VARIANT || "sap-docs").trim(); \
+      const config = JSON.parse(fs.readFileSync(`config/variants/${variant}.json`, "utf8")); \
+      console.log(config.tools?.ui5LibDiff ? "true" : "false"); \
+    ')" && \
+    if [ "$UI5_LIB_DIFF_ENABLED" = "true" ]; then \
+      npm run download:ui5-lib-diff; \
+    fi
+
 # Build TypeScript and FTS5 index
 RUN npm run build
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ An MCP server that gives AI assistants (Claude, Cursor, ChatGPT, etc.) access to
 |------|-------------|
 | `sap_discovery_center_search` | Search the SAP Discovery Center service catalog for BTP services by keyword, category, or license model. |
 | `sap_discovery_center_service` | Get comprehensive BTP service details: pricing plans, product roadmap, documentation links, and key features. Accepts a service UUID or name. |
-| `ui5_version_diff` | List FEATURE / FIX / DEPRECATED changes and SAPUI5 What's New entries for a version or range from a local all-changes bundle (`dist/data/ui5-lib-diff/all-changes.json`). `npm run setup` refreshes it automatically; use `npm run download:ui5-lib-diff` for a manual refresh. Pair with the [`ui5-version-upgrade` skill](.claude/skills/ui5-version-upgrade/SKILL.md) and `@ui5/mcp-server` for a full upgrade workflow. |
+| `ui5_version_diff` | List all matching FEATURE / FIX / DEPRECATED changes and SAPUI5 What's New entries for a version or range from a local all-changes bundle (`dist/data/ui5-lib-diff/all-changes.json`). `npm run setup` refreshes it automatically; use `npm run download:ui5-lib-diff` during setup/rebuild for a manual refresh. Pair with the [`ui5-version-upgrade` skill](.claude/skills/ui5-version-upgrade/SKILL.md) and `@ui5/mcp-server` for a full upgrade workflow. |
 
 ### `abap` variant only
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ An MCP server that gives AI assistants (Claude, Cursor, ChatGPT, etc.) access to
 |------|-------------|
 | `sap_discovery_center_search` | Search the SAP Discovery Center service catalog for BTP services by keyword, category, or license model. |
 | `sap_discovery_center_service` | Get comprehensive BTP service details: pricing plans, product roadmap, documentation links, and key features. Accepts a service UUID or name. |
-| `ui5_version_diff` | List FEATURE / FIX / DEPRECATED changes between two SAPUI5 or OpenUI5 versions from a local all-changes bundle (`dist/data/ui5-lib-diff/all-changes.json`). `npm run setup` refreshes it automatically; use `npm run download:ui5-lib-diff` for a manual refresh. Pair with the [`ui5-version-upgrade` skill](.claude/skills/ui5-version-upgrade/SKILL.md) and `@ui5/mcp-server` for a full upgrade workflow. |
+| `ui5_version_diff` | List FEATURE / FIX / DEPRECATED changes and SAPUI5 What's New entries for a version or range from a local all-changes bundle (`dist/data/ui5-lib-diff/all-changes.json`). `npm run setup` refreshes it automatically; use `npm run download:ui5-lib-diff` for a manual refresh. Pair with the [`ui5-version-upgrade` skill](.claude/skills/ui5-version-upgrade/SKILL.md) and `@ui5/mcp-server` for a full upgrade workflow. |
 
 ### `abap` variant only
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ An MCP server that gives AI assistants (Claude, Cursor, ChatGPT, etc.) access to
 |------|-------------|
 | `sap_discovery_center_search` | Search the SAP Discovery Center service catalog for BTP services by keyword, category, or license model. |
 | `sap_discovery_center_service` | Get comprehensive BTP service details: pricing plans, product roadmap, documentation links, and key features. Accepts a service UUID or name. |
-| `ui5_version_diff` | List FEATURE / FIX / DEPRECATED changes between two SAPUI5 or OpenUI5 versions. Source: [ui5-lib-diff](https://github.com/marianfoo/ui5-lib-diff) / [ui5-lib-diff.marianzeis.de](https://ui5-lib-diff.marianzeis.de/). Pair with the [`ui5-version-upgrade` skill](.claude/skills/ui5-version-upgrade/SKILL.md) and `@ui5/mcp-server` for a full upgrade workflow. |
+| `ui5_version_diff` | List FEATURE / FIX / DEPRECATED changes between two SAPUI5 or OpenUI5 versions from a local all-changes bundle (`dist/data/ui5-lib-diff/all-changes.json`). `npm run setup` refreshes it automatically; use `npm run download:ui5-lib-diff` for a manual refresh. Pair with the [`ui5-version-upgrade` skill](.claude/skills/ui5-version-upgrade/SKILL.md) and `@ui5/mcp-server` for a full upgrade workflow. |
 
 ### `abap` variant only
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ An MCP server that gives AI assistants (Claude, Cursor, ChatGPT, etc.) access to
 |------|-------------|
 | `sap_discovery_center_search` | Search the SAP Discovery Center service catalog for BTP services by keyword, category, or license model. |
 | `sap_discovery_center_service` | Get comprehensive BTP service details: pricing plans, product roadmap, documentation links, and key features. Accepts a service UUID or name. |
+| `ui5_version_diff` | List FEATURE / FIX / DEPRECATED changes between two SAPUI5 or OpenUI5 versions. Source: [ui5-lib-diff](https://github.com/marianfoo/ui5-lib-diff) / [ui5-lib-diff.marianzeis.de](https://ui5-lib-diff.marianzeis.de/). Pair with the [`ui5-version-upgrade` skill](.claude/skills/ui5-version-upgrade/SKILL.md) and `@ui5/mcp-server` for a full upgrade workflow. |
 
 ### `abap` variant only
 

--- a/config/variants/abap.json
+++ b/config/variants/abap.json
@@ -32,7 +32,8 @@
   "tools": {
     "abapLint": true,
     "abapFeatureMatrix": true,
-    "discoveryCenter": true
+    "discoveryCenter": true,
+    "ui5LibDiff": false
   },
   "server": {
     "stdioName": "mcp-abap-community-server",

--- a/config/variants/sap-docs.json
+++ b/config/variants/sap-docs.json
@@ -63,7 +63,8 @@
   "tools": {
     "abapLint": false,
     "abapFeatureMatrix": true,
-    "discoveryCenter": true
+    "discoveryCenter": true,
+    "ui5LibDiff": true
   },
   "server": {
     "stdioName": "Local SAP Docs",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test:urls:status": "npm run build:tsc && npx tsx test/url-status.ts",
     "test:prod": "node scripts/test-live-prod.mjs",
     "check-version": "node scripts/check-version.js",
+    "download:ui5-lib-diff": "node scripts/download-ui5-lib-diff.mjs",
     "setup": "bash setup.sh",
     "setup:submodules": "bash -lc 'git submodule sync --recursive && git submodule update --init --recursive --depth 1 && git submodule status --recursive'",
     "test:software-heroes": "npm run build:tsc && npx vitest run test/software-heroes-core.test.ts test/software-heroes-afm.test.ts test/software-heroes-content-search.test.ts",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "inspect": "npx @modelcontextprotocol/inspector",
     "test": "npm run test:url-generation && npm run test:integration",
     "test:sparse-checkout": "npx vitest run test/sparse-checkout.test.ts",
-    "test:url-generation": "npm run build:tsc && npx vitest run test/comprehensive-url-generation.test.ts test/source-url-matrix.test.ts test/search-response-schema.test.ts test/prompts.test.ts test/software-heroes-afm.test.ts",
+    "test:url-generation": "npm run build:tsc && npx vitest run test/comprehensive-url-generation.test.ts test/source-url-matrix.test.ts test/search-response-schema.test.ts test/prompts.test.ts test/software-heroes-afm.test.ts test/ui5-version-diff.test.ts",
     "test:url-generation:debug": "npm run build:tsc && DEBUG_TESTS=true npx vitest run test/comprehensive-url-generation.test.ts",
     "test:mcp-urls": "npm run build:tsc && npx vitest run test/mcp-search-url-verification.test.ts",
     "test:integration": "npm run build && node test/tools/run-tests.js",
@@ -31,7 +31,8 @@
     "test:software-heroes": "npm run build:tsc && npx vitest run test/software-heroes-core.test.ts test/software-heroes-afm.test.ts test/software-heroes-content-search.test.ts",
     "test:fetch-sap-help": "npm run build:tsc && npx vitest run test/fetch-sap-help.test.ts",
     "test:sap-objects": "npm run build:tsc && npx vitest run test/sap-released-objects.test.ts",
-    "test:embeddings": "npm run build:tsc && npx vitest run test/embeddings.test.ts"
+    "test:embeddings": "npm run build:tsc && npx vitest run test/embeddings.test.ts",
+    "test:ui5-version-diff": "npm run build:tsc && npx vitest run test/ui5-version-diff.test.ts"
   },
   "ts-node": {
     "esm": true

--- a/scripts/download-ui5-lib-diff.mjs
+++ b/scripts/download-ui5-lib-diff.mjs
@@ -25,6 +25,9 @@ function validateBundle(value) {
   if (!Array.isArray(datasets.SAPUI5) || !Array.isArray(datasets.OpenUI5)) {
     throw new Error("Expected datasets.SAPUI5 and datasets.OpenUI5 arrays");
   }
+  if ("whatsNew" in value && !Array.isArray(value.whatsNew)) {
+    throw new Error("Expected optional whatsNew field to be an array");
+  }
 }
 
 console.log(`Downloading UI5 lib diff bundle from ${sourceUrl}`);
@@ -59,5 +62,5 @@ await writeFile(tempPath, `${JSON.stringify(parsed)}\n`, "utf8");
 await rename(tempPath, targetPath);
 
 console.log(
-  `Wrote ${targetPath} (${parsed.datasets.SAPUI5.length} SAPUI5 versions, ${parsed.datasets.OpenUI5.length} OpenUI5 versions)`
+  `Wrote ${targetPath} (${parsed.datasets.SAPUI5.length} SAPUI5 versions, ${parsed.datasets.OpenUI5.length} OpenUI5 versions, ${(parsed.whatsNew || []).length} What's New entries)`
 );

--- a/scripts/download-ui5-lib-diff.mjs
+++ b/scripts/download-ui5-lib-diff.mjs
@@ -9,6 +9,10 @@ const sourceUrl =
 const targetPath =
   process.env.UI5_LIB_DIFF_BUNDLE_PATH ||
   "dist/data/ui5-lib-diff/all-changes.json";
+const timeoutMs = Number.parseInt(
+  process.env.UI5_LIB_DIFF_DOWNLOAD_TIMEOUT_MS || "60000",
+  10
+);
 
 function validateBundle(value) {
   if (!value || typeof value !== "object") {
@@ -25,7 +29,22 @@ function validateBundle(value) {
 
 console.log(`Downloading UI5 lib diff bundle from ${sourceUrl}`);
 
-const response = await fetch(sourceUrl);
+const controller = new AbortController();
+const timeout = setTimeout(() => controller.abort(), timeoutMs);
+let response;
+try {
+  response = await fetch(sourceUrl, { signal: controller.signal });
+} catch (error) {
+  if (error instanceof Error && error.name === "AbortError") {
+    throw new Error(
+      `Timed out after ${timeoutMs}ms while downloading UI5 lib diff bundle from ${sourceUrl}`
+    );
+  }
+  throw error;
+} finally {
+  clearTimeout(timeout);
+}
+
 if (!response.ok) {
   throw new Error(`Failed to download UI5 lib diff bundle: HTTP ${response.status}`);
 }

--- a/scripts/download-ui5-lib-diff.mjs
+++ b/scripts/download-ui5-lib-diff.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+import { mkdir, rename, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+const sourceUrl =
+  process.env.UI5_LIB_DIFF_DOWNLOAD_URL ||
+  "https://ui5-lib-diff.marianzeis.de/api/v1/all-changes.json";
+const targetPath =
+  process.env.UI5_LIB_DIFF_BUNDLE_PATH ||
+  "dist/data/ui5-lib-diff/all-changes.json";
+
+function validateBundle(value) {
+  if (!value || typeof value !== "object") {
+    throw new Error("Expected a JSON object");
+  }
+  const datasets = value.datasets;
+  if (!datasets || typeof datasets !== "object") {
+    throw new Error("Expected datasets object");
+  }
+  if (!Array.isArray(datasets.SAPUI5) || !Array.isArray(datasets.OpenUI5)) {
+    throw new Error("Expected datasets.SAPUI5 and datasets.OpenUI5 arrays");
+  }
+}
+
+console.log(`Downloading UI5 lib diff bundle from ${sourceUrl}`);
+
+const response = await fetch(sourceUrl);
+if (!response.ok) {
+  throw new Error(`Failed to download UI5 lib diff bundle: HTTP ${response.status}`);
+}
+
+const text = await response.text();
+const parsed = JSON.parse(text);
+validateBundle(parsed);
+
+await mkdir(dirname(targetPath), { recursive: true });
+const tempPath = `${targetPath}.tmp`;
+await writeFile(tempPath, `${JSON.stringify(parsed)}\n`, "utf8");
+await rename(tempPath, targetPath);
+
+console.log(
+  `Wrote ${targetPath} (${parsed.datasets.SAPUI5.length} SAPUI5 versions, ${parsed.datasets.OpenUI5.length} OpenUI5 versions)`
+);

--- a/setup.sh
+++ b/setup.sh
@@ -216,6 +216,27 @@ else
   git submodule status --recursive || true
 fi
 
+# Download local auxiliary datasets required by variant-enabled tools.
+_UI5_LIB_DIFF_ENABLED="$({
+  node --input-type=module -e '
+    import fs from "node:fs";
+    import path from "node:path";
+    const variant = (process.env.MCP_VARIANT || "").trim()
+      || (fs.existsSync(path.resolve(process.cwd(), ".mcp-variant"))
+          ? fs.readFileSync(path.resolve(process.cwd(), ".mcp-variant"), "utf8").trim()
+          : "")
+      || "sap-docs";
+    const configPath = path.resolve(process.cwd(), "config", "variants", `${variant}.json`);
+    const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+    console.log(config.tools?.ui5LibDiff ? "true" : "false");
+  ';
+} 2>/dev/null || true)"
+if [ "$_UI5_LIB_DIFF_ENABLED" = "true" ]; then
+  printf '📘 Downloading local UI5 lib diff bundle...\n'
+  npm run download:ui5-lib-diff
+fi
+unset _UI5_LIB_DIFF_ENABLED
+
 # Remove stale SQLite auxiliary files before building the FTS index.
 # A crashed previous build can leave orphaned -shm/-wal files behind; SQLite then
 # tries to apply the old WAL against the freshly created empty database and fails

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -8,10 +8,11 @@ import { search } from "./lib/search.js";
 import { CONFIG } from "./lib/config.js";
 import { getDocUrlConfig } from "./lib/metadata.js";
 import { generateDocumentationUrl, formatSearchResult } from "./lib/url-generation/index.js";
-import { getAllowedSubmodulePaths, getVariantConfig } from "./lib/variant.js";
+import { getAllowedSubmodulePaths, getVariantConfig, isToolEnabled } from "./lib/variant.js";
 import { BaseServerHandler } from "./lib/BaseServerHandler.js";
 import { prefetchFeatureMatrix } from "./lib/softwareHeroes/abapFeatureMatrix.js";
 import { prefetchReleasedObjects } from "./lib/sapReleasedObjects/index.js";
+import { prefetchUi5LibDiff } from "./lib/ui5LibDiff/index.js";
 import { loadEmbeddingModel } from "./lib/embeddingSearch.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -309,6 +310,12 @@ const server = createServer(async (req, res) => {
   prefetchFeatureMatrix();
   // Pre-load SAP Released Objects data (fire-and-forget, never blocks startup)
   prefetchReleasedObjects();
+  // Pre-warm the UI5 Lib Diff data when the tool is enabled (fire-and-forget)
+  if (isToolEnabled("ui5LibDiff")) {
+    prefetchUi5LibDiff().catch((err: Error) =>
+      console.warn("ui5 lib diff prefetch failed:", err.message)
+    );
+  }
   // Pre-load the embedding model so the first search is fast (fire-and-forget)
   loadEmbeddingModel().catch((err: Error) =>
     console.warn("embedding model pre-load failed:", err.message)

--- a/src/lib/BaseServerHandler.ts
+++ b/src/lib/BaseServerHandler.ts
@@ -656,7 +656,7 @@ FUNCTION NAME: ui5_version_diff
 List the new features, fixes, deprecations, and SAPUI5 What's New entries that landed between two UI5 releases, or inspect one exact release. Use this when planning or executing an upgrade so you know which workarounds can be dropped, which APIs are now deprecated, and which fixes might replace local patches.
 
 DATA SOURCE: local all-changes bundle at UI5_LIB_DIFF_BUNDLE_PATH (default: dist/data/ui5-lib-diff/all-changes.json).
-The runtime tool is local-only and does not fetch hosted URLs. Refresh the bundle during setup with npm run download:ui5-lib-diff.
+The runtime tool is local-only and does not fetch hosted URLs. Refresh the bundle during setup with npm run download:ui5-lib-diff. If a requested release is newer than the local bundle, the response includes meta.notes and meta.generatedAt so the caller can tell setup data is stale.
 
 RANGE SEMANTICS: returns changes that landed AFTER from_version up to and including to_version (i.e. what you gain by upgrading from from_version to to_version). If a requested patch version is unavailable, the tool uses the nearest lower available version with the same major.minor, matching the web app. For one release, pass version instead of a range.
 
@@ -667,17 +667,15 @@ PARAMETERS:
 • types (optional): subset of ["FEATURE", "FIX", "DEPRECATED"]. Defaults to all three.
 • ui5_library (optional): case-insensitive substring filter on the UI5 library, e.g. "sap.m", "sap.ui.core", "sap.fe".
 • query (optional): case-insensitive substring filter on change text and What's New title/description, e.g. "Table", "ObjectStatus", "ManagedObject".
-• limit (optional, default 200, max 1000): maximum diff entries and What's New entries returned. counts.* still reflect the full totals.
 
 RETURNS JSON with:
 • mode, library, from_version, to_version, version?
 • versionsInRange: versions covered by the range (newest first)
 • counts: { FEATURE, FIX, DEPRECATED } totals across the full range
 • totalEntries: sum of counts
-• truncated: true when totalEntries > entries.length
 • entries: [{ version, date, library, type, text, commit_url? }]
-• whatsNewEntries, whatsNewTotalEntries, whatsNewTruncated: SAPUI5 What's New entries for the same version/range
-• meta: { availableVersions, minVersion, maxVersion, sourceDataPath, cacheSource, requested, resolved, notes? } — "notes" is a list of soft signals (version resolution, out-of-range hints, coercion warnings)
+• whatsNewEntries, whatsNewTotalEntries: SAPUI5 What's New entries for the same version/range
+• meta: { availableVersions, minVersion, maxVersion, generatedAt, sourceDataPath, cacheSource, requested, resolved, notes? } — "notes" is a list of soft signals (version resolution, stale-bundle hints, out-of-range hints, coercion warnings)
 • sourceUrl: browser URL for human inspection of the same range
 
 USE CASES:
@@ -723,14 +721,7 @@ ui5_version_diff(from_version="1.96.0", to_version="1.120.0", query="ObjectStatu
                 },
                 query: {
                   type: "string",
-                  description: "Case-insensitive substring filter on the change text."
-                },
-                limit: {
-                  type: "number",
-                  description: "Maximum entries to return. Default 200, max 1000. counts.* still reflect the full totals.",
-                  minimum: 1,
-                  maximum: 1000,
-                  default: 200
+                  description: "Case-insensitive substring filter on change text and What's New title/description."
                 }
               },
               anyOf: [
@@ -760,7 +751,6 @@ ui5_version_diff(from_version="1.96.0", to_version="1.120.0", query="ObjectStatu
                   additionalProperties: false
                 },
                 totalEntries: { type: "number" },
-                truncated: { type: "boolean" },
                 entries: {
                   type: "array",
                   items: {
@@ -797,13 +787,16 @@ ui5_version_diff(from_version="1.96.0", to_version="1.120.0", query="ObjectStatu
                   }
                 },
                 whatsNewTotalEntries: { type: "number" },
-                whatsNewTruncated: { type: "boolean" },
                 meta: {
                   type: "object",
                   properties: {
                     availableVersions: { type: "number" },
                     minVersion: { type: "string" },
                     maxVersion: { type: "string" },
+                    generatedAt: {
+                      type: "string",
+                      description: "Generation timestamp from the local all-changes bundle, when available."
+                    },
                     sourceDataPath: {
                       type: "string",
                       description: "Local all-changes JSON bundle used for this result."
@@ -819,14 +812,14 @@ ui5_version_diff(from_version="1.96.0", to_version="1.120.0", query="ObjectStatu
                     notes: {
                       type: "array",
                       items: { type: "string" },
-                      description: "Soft signals: out-of-range hints, coercion warnings, empty-range tips."
+                      description: "Soft signals: stale-bundle hints, version resolution, out-of-range hints, coercion warnings, empty-range tips."
                     }
                   },
                   additionalProperties: true
                 },
                 sourceUrl: { type: "string" }
               },
-              required: ["mode", "library", "from_version", "to_version", "versionsInRange", "counts", "totalEntries", "truncated", "entries", "whatsNewEntries", "whatsNewTotalEntries", "whatsNewTruncated", "sourceUrl"],
+              required: ["mode", "library", "from_version", "to_version", "versionsInRange", "counts", "totalEntries", "entries", "whatsNewEntries", "whatsNewTotalEntries", "sourceUrl"],
               additionalProperties: true
             }
           },
@@ -1591,7 +1584,6 @@ RETURNS (JSON):
           types,
           ui5_library,
           query,
-          limit,
         } = (args ?? {}) as {
           library?: Ui5LibDiffLibrary;
           version?: string;
@@ -1600,7 +1592,6 @@ RETURNS (JSON):
           types?: Ui5ChangeType[];
           ui5_library?: string;
           query?: string;
-          limit?: number;
         };
 
         const timing = logger.logToolStart(
@@ -1627,7 +1618,7 @@ RETURNS (JSON):
         console.log(`🔍 [UI5_VERSION_DIFF] Library: ${library ?? "SAPUI5"}`);
         console.log(`🔍 [UI5_VERSION_DIFF] Range: ${version ?? `${from_version ?? "?"} -> ${to_version ?? "?"}`}`);
         console.log(`🔍 [UI5_VERSION_DIFF] Types: ${Array.isArray(types) ? types.join(",") : "ALL"}`);
-        console.log(`🔍 [UI5_VERSION_DIFF] ui5_library filter: ${ui5_library ?? "(none)"}, query: ${query ?? "(none)"}, limit: ${limit ?? 200}`);
+        console.log(`🔍 [UI5_VERSION_DIFF] ui5_library filter: ${ui5_library ?? "(none)"}, query: ${query ?? "(none)"}`);
         console.log(`🔍 [UI5_VERSION_DIFF] Cache: ${JSON.stringify(cacheStats)}`);
 
         try {
@@ -1639,17 +1630,16 @@ RETURNS (JSON):
             types,
             ui5_library,
             query,
-            limit,
           });
 
           console.log(
-            `🔍 [UI5_VERSION_DIFF] versions=${result.versionsInRange.length} total=${result.totalEntries} returned=${result.entries.length} truncated=${result.truncated}`
+            `🔍 [UI5_VERSION_DIFF] versions=${result.versionsInRange.length} total=${result.totalEntries} returned=${result.entries.length} whatsNew=${result.whatsNewTotalEntries}`
           );
           console.log(`🔍 [UI5_VERSION_DIFF] ========================================\n`);
 
           logger.logToolSuccess(name, timing.requestId, timing.startTime, result.entries.length, {
             totalEntries: result.totalEntries,
-            truncated: result.truncated,
+            whatsNewTotalEntries: result.whatsNewTotalEntries,
             versionsInRange: result.versionsInRange.length,
             counts: result.counts,
           });

--- a/src/lib/BaseServerHandler.ts
+++ b/src/lib/BaseServerHandler.ts
@@ -676,7 +676,7 @@ RETURNS JSON with:
 • totalEntries: sum of counts
 • truncated: true when totalEntries > entries.length
 • entries: [{ version, date, library, type, text, commit_url? }]
-• meta: { availableVersions, minVersion, maxVersion }
+• meta: { availableVersions, minVersion, maxVersion, notes? } — "notes" is a list of soft signals (out-of-range hints, coercion warnings)
 • sourceUrl
 
 USE CASES:
@@ -700,11 +700,11 @@ ui5_version_diff(from_version="1.96.0", to_version="1.120.0", query="ObjectStatu
                 },
                 from_version: {
                   type: "string",
-                  description: "Version you are upgrading from (exclusive bound), e.g. \"1.108.0\"."
+                  description: "Version you are upgrading from (exclusive bound), e.g. \"1.108.0\". Use the full x.y.z form — \"1.108\" matches only \"1.108.0\" exactly and will miss patch releases like \"1.108.5\". Must be strictly less than to_version."
                 },
                 to_version: {
                   type: "string",
-                  description: "Version you are upgrading to (inclusive bound), e.g. \"1.130.0\"."
+                  description: "Version you are upgrading to (inclusive bound), e.g. \"1.130.0\". Use the full x.y.z form. Must be strictly greater than from_version."
                 },
                 types: {
                   type: "array",
@@ -769,7 +769,12 @@ ui5_version_diff(from_version="1.96.0", to_version="1.120.0", query="ObjectStatu
                   properties: {
                     availableVersions: { type: "number" },
                     minVersion: { type: "string" },
-                    maxVersion: { type: "string" }
+                    maxVersion: { type: "string" },
+                    notes: {
+                      type: "array",
+                      items: { type: "string" },
+                      description: "Soft signals: out-of-range hints, coercion warnings, empty-range tips."
+                    }
                   },
                   additionalProperties: true
                 },

--- a/src/lib/BaseServerHandler.ts
+++ b/src/lib/BaseServerHandler.ts
@@ -39,6 +39,13 @@ import {
   getObjectDetails,
   getReleasedObjectsContext,
 } from "./sapReleasedObjects/index.js";
+import {
+  getUi5VersionDiff,
+  getUi5LibDiffCacheStats,
+  type Ui5ChangeType,
+  type Ui5LibDiffLibrary,
+  type Ui5VersionDiffResult,
+} from "./ui5LibDiff/index.js";
 
 import { SearchResponse } from "./types.js";
 import { logger } from "./logger.js";
@@ -641,6 +648,138 @@ USE CASES:
             }
           },
           {
+            name: "ui5_version_diff",
+            description: `UI5 VERSION DIFF: ui5_version_diff(library="SAPUI5", from_version="1.108.0", to_version="1.130.0")
+
+FUNCTION NAME: ui5_version_diff
+
+List the new features, fixes, and deprecations that landed between two UI5 releases. Use this when planning or executing an upgrade so you know which workarounds can be dropped, which APIs are now deprecated, and which fixes might replace local patches.
+
+DATA SOURCE: https://ui5-lib-diff.marianzeis.de/ (https://github.com/marianfoo/ui5-lib-diff)
+Consolidated change data is fetched per library and cached for 24 hours.
+
+RANGE SEMANTICS: returns changes that landed AFTER from_version up to and including to_version (i.e. what you gain by upgrading from from_version to to_version).
+
+PARAMETERS:
+• library (optional, default "SAPUI5"): "SAPUI5" or "OpenUI5".
+• from_version (required): version you are upgrading FROM, e.g. "1.108.0".
+• to_version (required): version you are upgrading TO, e.g. "1.130.0".
+• types (optional): subset of ["FEATURE", "FIX", "DEPRECATED"]. Defaults to all three.
+• ui5_library (optional): case-insensitive substring filter on the UI5 library, e.g. "sap.m", "sap.ui.core", "sap.fe".
+• query (optional): case-insensitive substring filter on the change text, e.g. "Table", "ObjectStatus", "ManagedObject".
+• limit (optional, default 200, max 1000): maximum entries returned. counts.* still reflect the full totals.
+
+RETURNS JSON with:
+• library, from_version, to_version
+• versionsInRange: versions covered by the range (newest first)
+• counts: { FEATURE, FIX, DEPRECATED } totals across the full range
+• totalEntries: sum of counts
+• truncated: true when totalEntries > entries.length
+• entries: [{ version, date, library, type, text, commit_url? }]
+• meta: { availableVersions, minVersion, maxVersion }
+• sourceUrl
+
+USE CASES:
+• Upgrade planning: "What deprecations should I clean up before moving 1.108 -> 1.130?"
+• Workaround cleanup: filter by query="<symptom>" to find the fix that replaces a local patch
+• Library-scoped review: ui5_library="sap.m" to focus on a single library
+• Combine with @ui5/mcp-server tools (run_ui5_linter, run_manifest_validation, get_api_reference) for code-level follow-up
+
+EXAMPLES:
+ui5_version_diff(from_version="1.108.0", to_version="1.130.0", types=["DEPRECATED"])
+ui5_version_diff(library="OpenUI5", from_version="1.120.0", to_version="1.130.0", ui5_library="sap.m")
+ui5_version_diff(from_version="1.96.0", to_version="1.120.0", query="ObjectStatus")`,
+            inputSchema: {
+              type: "object",
+              properties: {
+                library: {
+                  type: "string",
+                  enum: ["SAPUI5", "OpenUI5"],
+                  description: "Which UI5 flavour to diff. Defaults to SAPUI5.",
+                  default: "SAPUI5"
+                },
+                from_version: {
+                  type: "string",
+                  description: "Version you are upgrading from (exclusive bound), e.g. \"1.108.0\"."
+                },
+                to_version: {
+                  type: "string",
+                  description: "Version you are upgrading to (inclusive bound), e.g. \"1.130.0\"."
+                },
+                types: {
+                  type: "array",
+                  items: { type: "string", enum: ["FEATURE", "FIX", "DEPRECATED"] },
+                  description: "Filter to a subset of change types. Defaults to all three."
+                },
+                ui5_library: {
+                  type: "string",
+                  description: "Case-insensitive substring filter on UI5 library name (e.g. \"sap.m\", \"sap.ui.core\")."
+                },
+                query: {
+                  type: "string",
+                  description: "Case-insensitive substring filter on the change text."
+                },
+                limit: {
+                  type: "number",
+                  description: "Maximum entries to return. Default 200, max 1000. counts.* still reflect the full totals.",
+                  minimum: 1,
+                  maximum: 1000,
+                  default: 200
+                }
+              },
+              required: ["from_version", "to_version"]
+            },
+            outputSchema: {
+              type: "object",
+              properties: {
+                library: { type: "string" },
+                from_version: { type: "string" },
+                to_version: { type: "string" },
+                versionsInRange: { type: "array", items: { type: "string" } },
+                counts: {
+                  type: "object",
+                  properties: {
+                    FEATURE: { type: "number" },
+                    FIX: { type: "number" },
+                    DEPRECATED: { type: "number" }
+                  },
+                  required: ["FEATURE", "FIX", "DEPRECATED"],
+                  additionalProperties: false
+                },
+                totalEntries: { type: "number" },
+                truncated: { type: "boolean" },
+                entries: {
+                  type: "array",
+                  items: {
+                    type: "object",
+                    properties: {
+                      version: { type: "string" },
+                      date: { type: "string" },
+                      library: { type: "string" },
+                      type: { type: "string", enum: ["FEATURE", "FIX", "DEPRECATED"] },
+                      text: { type: "string" },
+                      commit_url: { type: "string" }
+                    },
+                    required: ["version", "library", "type", "text"],
+                    additionalProperties: true
+                  }
+                },
+                meta: {
+                  type: "object",
+                  properties: {
+                    availableVersions: { type: "number" },
+                    minVersion: { type: "string" },
+                    maxVersion: { type: "string" }
+                  },
+                  additionalProperties: true
+                },
+                sourceUrl: { type: "string" }
+              },
+              required: ["library", "from_version", "to_version", "versionsInRange", "counts", "totalEntries", "truncated", "entries", "sourceUrl"],
+              additionalProperties: true
+            }
+          },
+          {
             name: "sap_community_search",
             description: `SEARCH SAP COMMUNITY: sap_community_search(query="search terms")
 
@@ -965,6 +1104,10 @@ RETURNS (JSON):
         response.tools = response.tools.filter((tool) =>
           tool.name !== "sap_discovery_center_search" && tool.name !== "sap_discovery_center_service"
         );
+      }
+
+      if (!isToolEnabled("ui5LibDiff")) {
+        response.tools = response.tools.filter((tool) => tool.name !== "ui5_version_diff");
       }
 
       return response;
@@ -1374,6 +1517,98 @@ RETURNS (JSON):
           logger.logToolError(name, timing.requestId, timing.startTime, error);
           return createErrorResponse(
             `Error searching ABAP Feature Matrix: ${error}`,
+            timing.requestId
+          );
+        }
+      }
+
+      if (name === "ui5_version_diff") {
+        if (!isToolEnabled("ui5LibDiff")) {
+          const timing = logger.logToolStart(name, "disabled", clientMetadata);
+          logger.logToolError(name, timing.requestId, timing.startTime, new Error("Tool disabled for this variant"));
+          return createErrorResponse(
+            `Tool ${name} is disabled for MCP variant ${getVariantName()}.`,
+            timing.requestId
+          );
+        }
+
+        const {
+          library,
+          from_version,
+          to_version,
+          types,
+          ui5_library,
+          query,
+          limit,
+        } = (args ?? {}) as {
+          library?: Ui5LibDiffLibrary;
+          from_version?: string;
+          to_version?: string;
+          types?: Ui5ChangeType[];
+          ui5_library?: string;
+          query?: string;
+          limit?: number;
+        };
+
+        const timing = logger.logToolStart(
+          name,
+          `${library ?? "SAPUI5"} ${from_version ?? "?"} -> ${to_version ?? "?"}`,
+          clientMetadata
+        );
+
+        if (!from_version || !to_version) {
+          logger.logToolError(
+            name,
+            timing.requestId,
+            timing.startTime,
+            new Error("Missing from_version or to_version")
+          );
+          return createErrorResponse(
+            "Missing required parameters: from_version and to_version (e.g. from_version=\"1.108.0\", to_version=\"1.130.0\").",
+            timing.requestId
+          );
+        }
+
+        const cacheStats = getUi5LibDiffCacheStats();
+        console.log(`\n🔍 [UI5_VERSION_DIFF] ========================================`);
+        console.log(`🔍 [UI5_VERSION_DIFF] Library: ${library ?? "SAPUI5"}`);
+        console.log(`🔍 [UI5_VERSION_DIFF] Range: ${from_version} -> ${to_version}`);
+        console.log(`🔍 [UI5_VERSION_DIFF] Types: ${types ? types.join(",") : "ALL"}`);
+        console.log(`🔍 [UI5_VERSION_DIFF] ui5_library filter: ${ui5_library ?? "(none)"}, query: ${query ?? "(none)"}, limit: ${limit ?? 200}`);
+        console.log(`🔍 [UI5_VERSION_DIFF] Cache: ${JSON.stringify(cacheStats)}`);
+
+        try {
+          const result: Ui5VersionDiffResult = await getUi5VersionDiff({
+            library,
+            from_version,
+            to_version,
+            types,
+            ui5_library,
+            query,
+            limit,
+          });
+
+          console.log(
+            `🔍 [UI5_VERSION_DIFF] versions=${result.versionsInRange.length} total=${result.totalEntries} returned=${result.entries.length} truncated=${result.truncated}`
+          );
+          console.log(`🔍 [UI5_VERSION_DIFF] ========================================\n`);
+
+          logger.logToolSuccess(name, timing.requestId, timing.startTime, result.entries.length, {
+            totalEntries: result.totalEntries,
+            truncated: result.truncated,
+            versionsInRange: result.versionsInRange.length,
+            counts: result.counts,
+          });
+
+          return {
+            content: [{ type: "text", text: JSON.stringify(result) }],
+            structuredContent: result,
+          };
+        } catch (error) {
+          logger.logToolError(name, timing.requestId, timing.startTime, error);
+          const message = error instanceof Error ? error.message : String(error);
+          return createErrorResponse(
+            `Error running ui5_version_diff: ${message}`,
             timing.requestId
           );
         }

--- a/src/lib/BaseServerHandler.ts
+++ b/src/lib/BaseServerHandler.ts
@@ -655,8 +655,8 @@ FUNCTION NAME: ui5_version_diff
 
 List the new features, fixes, and deprecations that landed between two UI5 releases. Use this when planning or executing an upgrade so you know which workarounds can be dropped, which APIs are now deprecated, and which fixes might replace local patches.
 
-DATA SOURCE: https://ui5-lib-diff.marianzeis.de/ (https://github.com/marianfoo/ui5-lib-diff)
-Consolidated change data is fetched per library and cached for 24 hours.
+DATA SOURCE: local all-changes bundle at UI5_LIB_DIFF_BUNDLE_PATH (default: dist/data/ui5-lib-diff/all-changes.json).
+The runtime tool is local-only and does not fetch hosted URLs. Refresh the bundle during setup with npm run download:ui5-lib-diff.
 
 RANGE SEMANTICS: returns changes that landed AFTER from_version up to and including to_version (i.e. what you gain by upgrading from from_version to to_version).
 
@@ -676,8 +676,8 @@ RETURNS JSON with:
 • totalEntries: sum of counts
 • truncated: true when totalEntries > entries.length
 • entries: [{ version, date, library, type, text, commit_url? }]
-• meta: { availableVersions, minVersion, maxVersion, notes? } — "notes" is a list of soft signals (out-of-range hints, coercion warnings)
-• sourceUrl
+• meta: { availableVersions, minVersion, maxVersion, sourceDataPath, cacheSource, notes? } — "notes" is a list of soft signals (out-of-range hints, coercion warnings)
+• sourceUrl: browser URL for human inspection of the same range
 
 USE CASES:
 • Upgrade planning: "What deprecations should I clean up before moving 1.108 -> 1.130?"
@@ -770,6 +770,15 @@ ui5_version_diff(from_version="1.96.0", to_version="1.120.0", query="ObjectStatu
                     availableVersions: { type: "number" },
                     minVersion: { type: "string" },
                     maxVersion: { type: "string" },
+                    sourceDataPath: {
+                      type: "string",
+                      description: "Local all-changes JSON bundle used for this result."
+                    },
+                    cacheSource: {
+                      type: "string",
+                      enum: ["disk"],
+                      description: "The UI5 diff runtime is local-only; responses come from the local bundle on disk."
+                    },
                     notes: {
                       type: "array",
                       items: { type: "string" },

--- a/src/lib/BaseServerHandler.ts
+++ b/src/lib/BaseServerHandler.ts
@@ -653,30 +653,31 @@ USE CASES:
 
 FUNCTION NAME: ui5_version_diff
 
-List the new features, fixes, and deprecations that landed between two UI5 releases. Use this when planning or executing an upgrade so you know which workarounds can be dropped, which APIs are now deprecated, and which fixes might replace local patches.
+List the new features, fixes, deprecations, and SAPUI5 What's New entries that landed between two UI5 releases, or inspect one exact release. Use this when planning or executing an upgrade so you know which workarounds can be dropped, which APIs are now deprecated, and which fixes might replace local patches.
 
 DATA SOURCE: local all-changes bundle at UI5_LIB_DIFF_BUNDLE_PATH (default: dist/data/ui5-lib-diff/all-changes.json).
 The runtime tool is local-only and does not fetch hosted URLs. Refresh the bundle during setup with npm run download:ui5-lib-diff.
 
-RANGE SEMANTICS: returns changes that landed AFTER from_version up to and including to_version (i.e. what you gain by upgrading from from_version to to_version).
+RANGE SEMANTICS: returns changes that landed AFTER from_version up to and including to_version (i.e. what you gain by upgrading from from_version to to_version). If a requested patch version is unavailable, the tool uses the nearest lower available version with the same major.minor, matching the web app. For one release, pass version instead of a range.
 
 PARAMETERS:
 • library (optional, default "SAPUI5"): "SAPUI5" or "OpenUI5".
-• from_version (required): version you are upgrading FROM, e.g. "1.108.0".
-• to_version (required): version you are upgrading TO, e.g. "1.130.0".
+• version (optional): exact release to inspect, e.g. "1.130.0". Can also be supplied as the only from_version or only to_version.
+• from_version + to_version (optional range pair): version you are upgrading FROM/TO, e.g. "1.108.0" -> "1.130.0".
 • types (optional): subset of ["FEATURE", "FIX", "DEPRECATED"]. Defaults to all three.
 • ui5_library (optional): case-insensitive substring filter on the UI5 library, e.g. "sap.m", "sap.ui.core", "sap.fe".
-• query (optional): case-insensitive substring filter on the change text, e.g. "Table", "ObjectStatus", "ManagedObject".
-• limit (optional, default 200, max 1000): maximum entries returned. counts.* still reflect the full totals.
+• query (optional): case-insensitive substring filter on change text and What's New title/description, e.g. "Table", "ObjectStatus", "ManagedObject".
+• limit (optional, default 200, max 1000): maximum diff entries and What's New entries returned. counts.* still reflect the full totals.
 
 RETURNS JSON with:
-• library, from_version, to_version
+• mode, library, from_version, to_version, version?
 • versionsInRange: versions covered by the range (newest first)
 • counts: { FEATURE, FIX, DEPRECATED } totals across the full range
 • totalEntries: sum of counts
 • truncated: true when totalEntries > entries.length
 • entries: [{ version, date, library, type, text, commit_url? }]
-• meta: { availableVersions, minVersion, maxVersion, sourceDataPath, cacheSource, notes? } — "notes" is a list of soft signals (out-of-range hints, coercion warnings)
+• whatsNewEntries, whatsNewTotalEntries, whatsNewTruncated: SAPUI5 What's New entries for the same version/range
+• meta: { availableVersions, minVersion, maxVersion, sourceDataPath, cacheSource, requested, resolved, notes? } — "notes" is a list of soft signals (version resolution, out-of-range hints, coercion warnings)
 • sourceUrl: browser URL for human inspection of the same range
 
 USE CASES:
@@ -687,6 +688,7 @@ USE CASES:
 
 EXAMPLES:
 ui5_version_diff(from_version="1.108.0", to_version="1.130.0", types=["DEPRECATED"])
+ui5_version_diff(version="1.130.0", ui5_library="sap.m")
 ui5_version_diff(library="OpenUI5", from_version="1.120.0", to_version="1.130.0", ui5_library="sap.m")
 ui5_version_diff(from_version="1.96.0", to_version="1.120.0", query="ObjectStatus")`,
             inputSchema: {
@@ -698,13 +700,17 @@ ui5_version_diff(from_version="1.96.0", to_version="1.120.0", query="ObjectStatu
                   description: "Which UI5 flavour to diff. Defaults to SAPUI5.",
                   default: "SAPUI5"
                 },
+                version: {
+                  type: "string",
+                  description: "Single UI5 release to inspect, e.g. \"1.130.0\". If unavailable, resolves to the nearest lower available patch with the same major.minor."
+                },
                 from_version: {
                   type: "string",
-                  description: "Version you are upgrading from (exclusive bound), e.g. \"1.108.0\". Use the full x.y.z form — \"1.108\" matches only \"1.108.0\" exactly and will miss patch releases like \"1.108.5\". Must be strictly less than to_version."
+                  description: "Version you are upgrading from (exclusive bound), e.g. \"1.108.0\". If unavailable, resolves to the nearest lower available patch with the same major.minor."
                 },
                 to_version: {
                   type: "string",
-                  description: "Version you are upgrading to (inclusive bound), e.g. \"1.130.0\". Use the full x.y.z form. Must be strictly greater than from_version."
+                  description: "Version you are upgrading to (inclusive bound), e.g. \"1.130.0\". If unavailable, resolves to the nearest lower available patch with the same major.minor."
                 },
                 types: {
                   type: "array",
@@ -727,14 +733,21 @@ ui5_version_diff(from_version="1.96.0", to_version="1.120.0", query="ObjectStatu
                   default: 200
                 }
               },
-              required: ["from_version", "to_version"]
+              anyOf: [
+                { required: ["version"] },
+                { required: ["from_version", "to_version"] },
+                { required: ["from_version"] },
+                { required: ["to_version"] }
+              ]
             },
             outputSchema: {
               type: "object",
               properties: {
+                mode: { type: "string", enum: ["range", "version"] },
                 library: { type: "string" },
                 from_version: { type: "string" },
                 to_version: { type: "string" },
+                version: { type: "string" },
                 versionsInRange: { type: "array", items: { type: "string" } },
                 counts: {
                   type: "object",
@@ -764,6 +777,27 @@ ui5_version_diff(from_version="1.96.0", to_version="1.120.0", query="ObjectStatu
                     additionalProperties: true
                   }
                 },
+                whatsNewEntries: {
+                  type: "array",
+                  items: {
+                    type: "object",
+                    properties: {
+                      version: { type: "string" },
+                      title: { type: "string" },
+                      description: { type: "string" },
+                      type: { type: "string" },
+                      action: { type: "string" },
+                      category: { type: "string" },
+                      validAsOf: { type: "string" },
+                      url: { type: "string" },
+                      id: {}
+                    },
+                    required: ["version", "title", "description"],
+                    additionalProperties: true
+                  }
+                },
+                whatsNewTotalEntries: { type: "number" },
+                whatsNewTruncated: { type: "boolean" },
                 meta: {
                   type: "object",
                   properties: {
@@ -779,6 +813,9 @@ ui5_version_diff(from_version="1.96.0", to_version="1.120.0", query="ObjectStatu
                       enum: ["disk"],
                       description: "The UI5 diff runtime is local-only; responses come from the local bundle on disk."
                     },
+                    requested: { type: "object", additionalProperties: true },
+                    resolved: { type: "object", additionalProperties: true },
+                    whatsNewAvailable: { type: "number" },
                     notes: {
                       type: "array",
                       items: { type: "string" },
@@ -789,7 +826,7 @@ ui5_version_diff(from_version="1.96.0", to_version="1.120.0", query="ObjectStatu
                 },
                 sourceUrl: { type: "string" }
               },
-              required: ["library", "from_version", "to_version", "versionsInRange", "counts", "totalEntries", "truncated", "entries", "sourceUrl"],
+              required: ["mode", "library", "from_version", "to_version", "versionsInRange", "counts", "totalEntries", "truncated", "entries", "whatsNewEntries", "whatsNewTotalEntries", "whatsNewTruncated", "sourceUrl"],
               additionalProperties: true
             }
           },
@@ -1548,6 +1585,7 @@ RETURNS (JSON):
 
         const {
           library,
+          version,
           from_version,
           to_version,
           types,
@@ -1556,6 +1594,7 @@ RETURNS (JSON):
           limit,
         } = (args ?? {}) as {
           library?: Ui5LibDiffLibrary;
+          version?: string;
           from_version?: string;
           to_version?: string;
           types?: Ui5ChangeType[];
@@ -1566,19 +1605,19 @@ RETURNS (JSON):
 
         const timing = logger.logToolStart(
           name,
-          `${library ?? "SAPUI5"} ${from_version ?? "?"} -> ${to_version ?? "?"}`,
+          `${library ?? "SAPUI5"} ${version ?? `${from_version ?? "?"} -> ${to_version ?? "?"}`}`,
           clientMetadata
         );
 
-        if (!from_version || !to_version) {
+        if (!version && !from_version && !to_version) {
           logger.logToolError(
             name,
             timing.requestId,
             timing.startTime,
-            new Error("Missing from_version or to_version")
+            new Error("Missing version or range")
           );
           return createErrorResponse(
-            "Missing required parameters: from_version and to_version (e.g. from_version=\"1.108.0\", to_version=\"1.130.0\").",
+            "Missing required parameters: pass version=\"1.130.0\" for one release, or from_version=\"1.108.0\" and to_version=\"1.130.0\" for a range.",
             timing.requestId
           );
         }
@@ -1586,14 +1625,15 @@ RETURNS (JSON):
         const cacheStats = getUi5LibDiffCacheStats();
         console.log(`\n🔍 [UI5_VERSION_DIFF] ========================================`);
         console.log(`🔍 [UI5_VERSION_DIFF] Library: ${library ?? "SAPUI5"}`);
-        console.log(`🔍 [UI5_VERSION_DIFF] Range: ${from_version} -> ${to_version}`);
-        console.log(`🔍 [UI5_VERSION_DIFF] Types: ${types ? types.join(",") : "ALL"}`);
+        console.log(`🔍 [UI5_VERSION_DIFF] Range: ${version ?? `${from_version ?? "?"} -> ${to_version ?? "?"}`}`);
+        console.log(`🔍 [UI5_VERSION_DIFF] Types: ${Array.isArray(types) ? types.join(",") : "ALL"}`);
         console.log(`🔍 [UI5_VERSION_DIFF] ui5_library filter: ${ui5_library ?? "(none)"}, query: ${query ?? "(none)"}, limit: ${limit ?? 200}`);
         console.log(`🔍 [UI5_VERSION_DIFF] Cache: ${JSON.stringify(cacheStats)}`);
 
         try {
           const result: Ui5VersionDiffResult = await getUi5VersionDiff({
             library,
+            version,
             from_version,
             to_version,
             types,

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -66,4 +66,17 @@ export const CONFIG = {
 
   // Directory where the embedding model is cached (gitignored, in-project)
   MODELS_DIR: process.env.MODELS_DIR || "dist/models",
+
+  // ---------------------------------------------------------------------------
+  // UI5 Lib Diff Configuration
+  // ---------------------------------------------------------------------------
+
+  // Cache TTL in milliseconds (default: 24 hours)
+  UI5_LIB_DIFF_CACHE_TTL_MS: Number(process.env.UI5_LIB_DIFF_CACHE_TTL_MS || 86400000),
+
+  // Request timeout when fetching the consolidated JSON files (default: 30 seconds)
+  UI5_LIB_DIFF_TIMEOUT_MS: Number(process.env.UI5_LIB_DIFF_TIMEOUT_MS || 30000),
+
+  // Disk cache directory for ui5-lib-diff data (survives server restarts)
+  UI5_LIB_DIFF_CACHE_DIR: process.env.UI5_LIB_DIFF_CACHE_DIR || "dist/data/ui5-lib-diff",
 };

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -74,9 +74,13 @@ export const CONFIG = {
   // Cache TTL in milliseconds (default: 24 hours)
   UI5_LIB_DIFF_CACHE_TTL_MS: Number(process.env.UI5_LIB_DIFF_CACHE_TTL_MS || 86400000),
 
-  // Request timeout when fetching the consolidated JSON files (default: 30 seconds)
-  UI5_LIB_DIFF_TIMEOUT_MS: Number(process.env.UI5_LIB_DIFF_TIMEOUT_MS || 30000),
+  // Local all-changes bundle consumed by ui5_version_diff at runtime.
+  UI5_LIB_DIFF_BUNDLE_PATH: process.env.UI5_LIB_DIFF_BUNDLE_PATH || "dist/data/ui5-lib-diff/all-changes.json",
 
-  // Disk cache directory for ui5-lib-diff data (survives server restarts)
-  UI5_LIB_DIFF_CACHE_DIR: process.env.UI5_LIB_DIFF_CACHE_DIR || "dist/data/ui5-lib-diff",
+  // Setup-time source URL for downloading the local all-changes bundle.
+  // The runtime tool does not fetch this URL; it only reads UI5_LIB_DIFF_BUNDLE_PATH.
+  UI5_LIB_DIFF_DOWNLOAD_URL: process.env.UI5_LIB_DIFF_DOWNLOAD_URL || "https://ui5-lib-diff.marianzeis.de/api/v1/all-changes.json",
+
+  // Human-facing UI route returned in tool metadata for inspection.
+  UI5_LIB_DIFF_APP_BASE_URL: process.env.UI5_LIB_DIFF_APP_BASE_URL || "https://ui5-lib-diff.marianzeis.de",
 };

--- a/src/lib/ui5LibDiff/index.ts
+++ b/src/lib/ui5LibDiff/index.ts
@@ -13,6 +13,7 @@ export {
   type Ui5VersionDiffOptions,
   type Ui5VersionDiffResult,
   type Ui5ChangeEntry,
+  type Ui5WhatsNewEntry,
   type Ui5ChangeType,
   type Ui5LibDiffLibrary,
 } from "./ui5VersionDiff.js";

--- a/src/lib/ui5LibDiff/index.ts
+++ b/src/lib/ui5LibDiff/index.ts
@@ -1,0 +1,18 @@
+/**
+ * UI5 Version Diff module - exports the public API for the ui5_version_diff tool.
+ */
+
+export {
+  getUi5VersionDiff,
+  prefetchUi5LibDiff,
+  getUi5LibDiffCacheStats,
+  filterUi5Diff,
+  compareUi5Versions,
+  parseUi5Version,
+  normalizeChangeType,
+  type Ui5VersionDiffOptions,
+  type Ui5VersionDiffResult,
+  type Ui5ChangeEntry,
+  type Ui5ChangeType,
+  type Ui5LibDiffLibrary,
+} from "./ui5VersionDiff.js";

--- a/src/lib/ui5LibDiff/ui5VersionDiff.ts
+++ b/src/lib/ui5LibDiff/ui5VersionDiff.ts
@@ -8,7 +8,7 @@
 // `library` selector so callers can pick the flavour matching their project.
 
 import { readFile, writeFile, mkdir } from "node:fs/promises";
-import { dirname } from "node:path";
+import { dirname, join } from "node:path";
 import { TtlCache } from "../softwareHeroes/core.js";
 import { CONFIG } from "../config.js";
 
@@ -80,6 +80,8 @@ export interface Ui5VersionDiffResult {
     availableVersions: number;
     minVersion?: string;
     maxVersion?: string;
+    /** Soft signals for the caller: out-of-range hints, coercion notes, etc. */
+    notes?: string[];
   };
 }
 
@@ -104,7 +106,9 @@ const memoryCache = new TtlCache<RawVersionBlock[]>(
 );
 
 function diskCachePath(library: Ui5LibDiffLibrary): string {
-  return CONFIG.UI5_LIB_DIFF_CACHE_DIR + `/${FILE_NAMES[library]}`;
+  // CWD-relative by default (see CONFIG.UI5_LIB_DIFF_CACHE_DIR). The disk
+  // cache is wiped whenever `dist/` is removed, e.g. during a full build.
+  return join(CONFIG.UI5_LIB_DIFF_CACHE_DIR, FILE_NAMES[library]);
 }
 
 // ---------------------------------------------------------------------------
@@ -255,6 +259,10 @@ async function loadConsolidated(
     const fresh = await fetchConsolidated(library);
     memoryCache.set(library, fresh);
     reportNonCanonicalDrift(library, fresh);
+    // Fire-and-forget on the request hot path: the caller already has the
+    // data, the disk write is just a future-restart optimization. The
+    // prefetch path below awaits this same write because there is no
+    // caller waiting.
     writeDiskCache(library, fresh).catch((err) =>
       console.error(
         `⚠️ [ui5VersionDiff] Failed to persist ${library} disk cache:`,
@@ -294,13 +302,25 @@ export function filterUi5Diff(
   options: Ui5VersionDiffOptions
 ): Ui5VersionDiffResult {
   const library = options.library ?? "SAPUI5";
+  const notes: string[] = [];
+
+  // Defensive coercion: an MCP client that doesn't validate against the
+  // input schema could send `types: "FEATURE"` (string). Without this
+  // guard, `new Set("FEATURE")` would yield Set{"F","E","A","T","U","R"}
+  // and silently match nothing.
+  const requestedTypes = Array.isArray(options.types)
+    ? options.types.filter((t): t is Ui5ChangeType =>
+        typeof t === "string" && CANONICAL_TYPES.has(t as Ui5ChangeType)
+      )
+    : [];
   const typesAllowed = new Set<Ui5ChangeType>(
-    options.types && options.types.length > 0
-      ? options.types
+    requestedTypes.length > 0
+      ? requestedTypes
       : ["FEATURE", "FIX", "DEPRECATED"]
   );
+
   const limit = Math.min(
-    Math.max(options.limit ?? DEFAULT_LIMIT, 1),
+    Math.max(Math.floor(options.limit ?? DEFAULT_LIMIT), 1),
     MAX_LIMIT
   );
   const libFilter = options.ui5_library?.toLowerCase().trim() || "";
@@ -367,6 +387,29 @@ export function filterUi5Diff(
   // Sort version list newest-first for display.
   versionsInRange.sort((a, b) => compareUi5Versions(b, a));
 
+  // Surface out-of-range hints so the caller (LLM or human) knows when the
+  // requested range falls outside what the dataset actually carries.
+  if (minVersion && compareUi5Versions(options.from_version, minVersion) < 0) {
+    notes.push(
+      `from_version ${options.from_version} predates the oldest version in the dataset (${minVersion}); the lower bound is effectively that version.`
+    );
+  }
+  if (maxVersion && compareUi5Versions(options.to_version, maxVersion) > 0) {
+    notes.push(
+      `to_version ${options.to_version} is newer than the newest version in the dataset (${maxVersion}); upgrade to a future release isn't covered yet.`
+    );
+  }
+  if (versionsInRange.length === 0) {
+    notes.push(
+      `No versions matched the range (${options.from_version}, ${options.to_version}]. Tip: use the full x.y.z form — "1.120" matches "1.120.0" exactly and will miss "1.120.5".`
+    );
+  }
+  if (Array.isArray(options.types) && requestedTypes.length === 0 && options.types.length > 0) {
+    notes.push(
+      `types parameter contained no valid values (expected subset of FEATURE / FIX / DEPRECATED); falling back to all three.`
+    );
+  }
+
   const totalEntries = counts.FEATURE + counts.FIX + counts.DEPRECATED;
 
   return {
@@ -383,6 +426,7 @@ export function filterUi5Diff(
       availableVersions: data.length,
       minVersion,
       maxVersion,
+      ...(notes.length > 0 ? { notes } : {}),
     },
   };
 }
@@ -397,9 +441,12 @@ export async function getUi5VersionDiff(
   if (!options.from_version || !options.to_version) {
     throw new Error("ui5_version_diff requires from_version and to_version");
   }
-  if (compareUi5Versions(options.from_version, options.to_version) > 0) {
+  // Strict <: from == to is a degenerate range that, given the
+  // exclusive-from / inclusive-to semantics, would silently return zero
+  // entries. Surface that as an error so the caller can fix the inputs.
+  if (compareUi5Versions(options.from_version, options.to_version) >= 0) {
     throw new Error(
-      `from_version (${options.from_version}) must be <= to_version (${options.to_version})`
+      `from_version (${options.from_version}) must be strictly less than to_version (${options.to_version}). The range is exclusive at from_version and inclusive at to_version, so from == to has no changes by definition.`
     );
   }
 

--- a/src/lib/ui5LibDiff/ui5VersionDiff.ts
+++ b/src/lib/ui5LibDiff/ui5VersionDiff.ts
@@ -136,17 +136,65 @@ export function compareUi5Versions(a: string, b: string): number {
 // Type normalization
 // ---------------------------------------------------------------------------
 
+const CANONICAL_TYPES: ReadonlySet<Ui5ChangeType> = new Set([
+  "FEATURE",
+  "FIX",
+  "DEPRECATED",
+]);
+
 /**
- * The upstream data mixes casing and contains internal/legacy markers
- * ("Feature", "feature", "INETRNAL" typo, "[INTERNAL] ALP", "LEGACY").
- * We only expose the three categories users actually care about.
+ * The upstream data is canonicalized at the source as of
+ * https://github.com/marianfoo/ui5-lib-diff (parseChanges.js#normalizeType):
+ * every `type` is one of "FEATURE" | "FIX" | "DEPRECATED" and the historic
+ * casing variants ("Feature", "feature", "Fix") plus internal/legacy
+ * markers ("INTERNAL", the "INETRNAL" typo, "[INTERNAL] ALP", "LEGACY")
+ * are dropped before the consolidated JSON is written.
+ *
+ * We keep a defensive uppercase path so a stale data file (e.g. between
+ * upstream merge and the next weekly refresh) doesn't break the tool.
+ * Drift is surfaced via `reportNonCanonicalDrift` during load.
  */
 export function normalizeChangeType(raw: string): Ui5ChangeType | null {
-  const t = (raw ?? "").trim().toUpperCase();
-  if (t === "FEATURE") return "FEATURE";
-  if (t === "FIX") return "FIX";
-  if (t === "DEPRECATED") return "DEPRECATED";
+  if (typeof raw === "string" && CANONICAL_TYPES.has(raw as Ui5ChangeType)) {
+    return raw as Ui5ChangeType;
+  }
+  const upper = (raw ?? "").trim().toUpperCase();
+  if (CANONICAL_TYPES.has(upper as Ui5ChangeType)) {
+    return upper as Ui5ChangeType;
+  }
   return null;
+}
+
+/**
+ * After loading a dataset, count any non-canonical `type` values and emit
+ * a single grouped warning. Helps spot upstream regressions early without
+ * spamming the log on every cache hit.
+ */
+function reportNonCanonicalDrift(
+  library: Ui5LibDiffLibrary,
+  data: RawVersionBlock[]
+): void {
+  const driftCounts = new Map<string, number>();
+  for (const block of data) {
+    for (const lib of block.libraries ?? []) {
+      for (const change of lib.changes ?? []) {
+        if (
+          typeof change.type !== "string" ||
+          !CANONICAL_TYPES.has(change.type as Ui5ChangeType)
+        ) {
+          const key =
+            typeof change.type === "string" ? change.type : String(change.type);
+          driftCounts.set(key, (driftCounts.get(key) ?? 0) + 1);
+        }
+      }
+    }
+  }
+  if (driftCounts.size > 0) {
+    console.warn(
+      `[ui5VersionDiff] ${library} contains non-canonical types — expected upstream to canonicalize. Drift:`,
+      Object.fromEntries(driftCounts)
+    );
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -206,6 +254,7 @@ async function loadConsolidated(
   try {
     const fresh = await fetchConsolidated(library);
     memoryCache.set(library, fresh);
+    reportNonCanonicalDrift(library, fresh);
     writeDiskCache(library, fresh).catch((err) =>
       console.error(
         `⚠️ [ui5VersionDiff] Failed to persist ${library} disk cache:`,
@@ -221,6 +270,7 @@ async function loadConsolidated(
     const disk = await readDiskCache(library);
     if (disk) {
       memoryCache.set(library, disk);
+      reportNonCanonicalDrift(library, disk);
       return disk;
     }
     throw new Error(
@@ -368,6 +418,7 @@ export async function prefetchUi5LibDiff(): Promise<void> {
       try {
         const data = await fetchConsolidated(library);
         memoryCache.set(library, data);
+        reportNonCanonicalDrift(library, data);
         await writeDiskCache(library, data);
         console.log(
           `✅ [ui5VersionDiff] Prefetched ${library}: ${data.length} versions`
@@ -380,6 +431,7 @@ export async function prefetchUi5LibDiff(): Promise<void> {
         const disk = await readDiskCache(library);
         if (disk) {
           memoryCache.set(library, disk);
+          reportNonCanonicalDrift(library, disk);
           console.log(
             `📂 [ui5VersionDiff] Loaded ${library} from disk cache: ${disk.length} versions`
           );

--- a/src/lib/ui5LibDiff/ui5VersionDiff.ts
+++ b/src/lib/ui5LibDiff/ui5VersionDiff.ts
@@ -3,7 +3,7 @@
 // https://github.com/marianfoo/ui5-lib-diff (powering https://ui5-lib-diff.marianzeis.de/).
 //
 // The preferred static API is a one-file bundle:
-//   { schemaVersion, generatedAt, datasets: { SAPUI5: [...], OpenUI5: [...] } }
+//   { schemaVersion, generatedAt, datasets: { SAPUI5: [...], OpenUI5: [...] }, whatsNew: [...] }
 // Each dataset is an array of version blocks:
 //   [{ version, date, libraries: [{ library, changes: [{ type, text, commit_url?, id? }] }] }]
 // Runtime access is local-only; setup/download scripts are responsible for
@@ -47,6 +47,19 @@ interface RawBundle {
   schemaVersion?: number;
   generatedAt?: string;
   datasets?: Partial<Record<Ui5LibDiffLibrary, RawVersionBlock[]>>;
+  whatsNew?: RawWhatsNewEntry[];
+}
+
+interface RawWhatsNewEntry {
+  id?: number | string;
+  Version?: string;
+  Title?: string;
+  Description?: string;
+  Type?: string;
+  Action?: string;
+  Category?: string;
+  Valid_as_Of?: string;
+  outputloio?: string;
 }
 
 /** A single filtered change emitted by the tool. */
@@ -61,8 +74,10 @@ export interface Ui5ChangeEntry {
 
 export interface Ui5VersionDiffOptions {
   library?: Ui5LibDiffLibrary;
-  from_version: string;
-  to_version: string;
+  /** Exact version to inspect. If provided, range semantics do not apply. */
+  version?: string;
+  from_version?: string;
+  to_version?: string;
   /** Filter to specific change types. Defaults to all three. */
   types?: Ui5ChangeType[];
   /** Substring filter on the UI5 library name (case-insensitive, e.g. "sap.m"). */
@@ -73,16 +88,33 @@ export interface Ui5VersionDiffOptions {
   limit?: number;
 }
 
+export interface Ui5WhatsNewEntry {
+  version: string;
+  title: string;
+  description: string;
+  type?: string;
+  action?: string;
+  category?: string;
+  validAsOf?: string;
+  url?: string;
+  id?: number | string;
+}
+
 export interface Ui5VersionDiffResult {
+  mode: "range" | "version";
   library: Ui5LibDiffLibrary;
   from_version: string;
   to_version: string;
+  version?: string;
   /** Versions that fall in the requested range (exclusive of from, inclusive of to). */
   versionsInRange: string[];
   counts: Record<Ui5ChangeType, number>;
   totalEntries: number;
   truncated: boolean;
   entries: Ui5ChangeEntry[];
+  whatsNewEntries: Ui5WhatsNewEntry[];
+  whatsNewTotalEntries: number;
+  whatsNewTruncated: boolean;
   sourceUrl: string;
   meta: {
     availableVersions: number;
@@ -90,6 +122,17 @@ export interface Ui5VersionDiffResult {
     maxVersion?: string;
     sourceDataPath?: string;
     cacheSource?: "disk";
+    requested?: {
+      version?: string;
+      from_version?: string;
+      to_version?: string;
+    };
+    resolved?: {
+      version?: string;
+      from_version?: string;
+      to_version?: string;
+    };
+    whatsNewAvailable?: number;
     /** Soft signals for the caller: out-of-range hints, coercion notes, etc. */
     notes?: string[];
   };
@@ -106,12 +149,14 @@ const MAX_LIMIT = 1000;
 
 interface LoadedDataset {
   data: RawVersionBlock[];
+  whatsNew: RawWhatsNewEntry[];
   sourceDataPath: string;
   cacheSource: "disk";
 }
 
 interface LoadedBundle {
   datasets: Record<Ui5LibDiffLibrary, RawVersionBlock[]>;
+  whatsNew: RawWhatsNewEntry[];
   sourceDataPath: string;
   cacheSource: "disk";
   generatedAt?: string;
@@ -130,9 +175,11 @@ function normalizeBaseUrl(url: string): string {
 }
 
 function buildUi5LibDiffAppUrl(options: Ui5VersionDiffOptions): string {
+  const from = options.from_version ?? options.version ?? "";
+  const to = options.to_version ?? options.version ?? "";
   const params = new URLSearchParams({
-    versionFrom: options.from_version,
-    versionTo: options.to_version,
+    versionFrom: from,
+    versionTo: to,
     ui5Type: options.library ?? "SAPUI5",
   });
   return `${normalizeBaseUrl(CONFIG.UI5_LIB_DIFF_APP_BASE_URL)}/?${params.toString()}`;
@@ -165,6 +212,33 @@ export function compareUi5Versions(a: string, b: string): number {
     if (aa[i] !== bb[i]) return aa[i] - bb[i];
   }
   return 0;
+}
+
+function ui5MinorKey(version: string): string {
+  return version
+    .trim()
+    .replace(/^v/i, "")
+    .split(".")
+    .slice(0, 2)
+    .join(".");
+}
+
+function normalizeWhatsNewVersion(version: string): string {
+  const [major, minor] = parseUi5Version(version);
+  return `${major}.${minor}`;
+}
+
+function stripHtml(value = ""): string {
+  return value
+    .replace(/<[^>]*>/g, " ")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\s+/g, " ")
+    .trim();
 }
 
 // ---------------------------------------------------------------------------
@@ -255,6 +329,7 @@ function parseBundleJson(
       SAPUI5: sapui5,
       OpenUI5: openui5,
     },
+    whatsNew: Array.isArray(raw?.whatsNew) ? raw.whatsNew : [],
     sourceDataPath,
     cacheSource: "disk",
     generatedAt:
@@ -268,6 +343,7 @@ function cacheLoadedBundle(bundle: LoadedBundle, reportDrift = true): void {
     const data = bundle.datasets[library];
     memoryCache.set(library, {
       data,
+      whatsNew: bundle.whatsNew,
       sourceDataPath: bundle.sourceDataPath,
       cacheSource: bundle.cacheSource,
     });
@@ -318,16 +394,128 @@ async function loadConsolidated(
 // Filtering
 // ---------------------------------------------------------------------------
 
+function resolveAvailableVersion(
+  availableVersions: string[],
+  requested: string,
+  label: "version" | "from_version" | "to_version",
+  notes: string[]
+): string {
+  if (availableVersions.includes(requested)) {
+    return requested;
+  }
+
+  const requestedMinor = ui5MinorKey(requested);
+  const nearest = availableVersions
+    .filter((version) => ui5MinorKey(version) === requestedMinor)
+    .sort((a, b) => compareUi5Versions(b, a))
+    .find((version) => compareUi5Versions(version, requested) <= 0);
+
+  if (nearest) {
+    notes.push(
+      `${label} ${requested} is not available; using nearest available ${requestedMinor}.x version ${nearest}.`
+    );
+    return nearest;
+  }
+
+  notes.push(
+    `${label} ${requested} is not available and no ${requestedMinor}.x version exists in the dataset.`
+  );
+  return requested;
+}
+
+function whatsNewUrl(item: RawWhatsNewEntry): string | undefined {
+  return item.outputloio
+    ? `https://help.sap.com/whats-new/67f60363b57f4ac0b23efd17fa192d60?locale=en-US&Component=${item.outputloio}`
+    : undefined;
+}
+
+function filterWhatsNew(
+  whatsNew: RawWhatsNewEntry[],
+  options: Ui5VersionDiffOptions,
+  mode: "range" | "version",
+  fromVersion: string,
+  toVersion: string,
+  limit: number
+): {
+  entries: Ui5WhatsNewEntry[];
+  totalEntries: number;
+  truncated: boolean;
+} {
+  const queryFilter = options.query?.toLowerCase().trim() || "";
+  const allowedMinorKeys = new Set<string>();
+
+  if (mode === "version") {
+    allowedMinorKeys.add(normalizeWhatsNewVersion(toVersion));
+  }
+
+  const matching = whatsNew.filter((item) => {
+    if (!item.Version) return false;
+    const itemVersion = `${item.Version}.0`;
+    const inRange =
+      mode === "version"
+        ? allowedMinorKeys.has(normalizeWhatsNewVersion(itemVersion))
+        : compareUi5Versions(itemVersion, fromVersion) > 0 &&
+          compareUi5Versions(itemVersion, toVersion) <= 0;
+    if (!inRange) return false;
+
+    if (queryFilter) {
+      const searchable = [
+        item.Title,
+        item.Description,
+        item.Type,
+        item.Action,
+        item.Category,
+      ]
+        .map((value) => stripHtml(value ?? ""))
+        .join(" ")
+        .toLowerCase();
+      if (!searchable.includes(queryFilter)) return false;
+    }
+
+    return true;
+  });
+
+  const entries = matching.slice(0, limit).map((item) => ({
+    version: item.Version ?? "",
+    title: stripHtml(item.Title ?? ""),
+    description: stripHtml(item.Description ?? ""),
+    type: item.Type,
+    action: item.Action,
+    category: item.Category,
+    validAsOf: item.Valid_as_Of,
+    url: whatsNewUrl(item),
+    id: item.id,
+  }));
+
+  return {
+    entries,
+    totalEntries: matching.length,
+    truncated: matching.length > entries.length,
+  };
+}
+
 /**
  * Apply the diff filters to an already-loaded dataset.
  * Pure function so unit tests can drive it from fixtures.
  */
 export function filterUi5Diff(
   data: RawVersionBlock[],
-  options: Ui5VersionDiffOptions
+  options: Ui5VersionDiffOptions,
+  whatsNew: RawWhatsNewEntry[] = []
 ): Ui5VersionDiffResult {
   const library = options.library ?? "SAPUI5";
   const notes: string[] = [];
+  const requestedVersion =
+    options.version ??
+    (!options.to_version && options.from_version ? options.from_version : undefined) ??
+    (!options.from_version && options.to_version ? options.to_version : undefined);
+  const mode: "range" | "version" =
+    requestedVersion ||
+    (options.from_version &&
+      options.to_version &&
+      compareUi5Versions(options.from_version, options.to_version) === 0)
+      ? "version"
+      : "range";
 
   // Defensive coercion: an MCP client that doesn't validate against the
   // input schema could send `types: "FEATURE"` (string). Without this
@@ -350,9 +538,36 @@ export function filterUi5Diff(
   );
   const libFilter = options.ui5_library?.toLowerCase().trim() || "";
   const queryFilter = options.query?.toLowerCase().trim() || "";
-
-  const fromCmp = options.from_version;
-  const toCmp = options.to_version;
+  const availableVersions = data
+    .map((block) => block.version)
+    .filter((version): version is string => Boolean(version));
+  const resolvedVersion =
+    mode === "version"
+      ? resolveAvailableVersion(
+          availableVersions,
+          requestedVersion ?? options.from_version ?? options.to_version ?? "",
+          "version",
+          notes
+        )
+      : undefined;
+  const fromCmp =
+    mode === "range"
+      ? resolveAvailableVersion(
+          availableVersions,
+          options.from_version ?? "",
+          "from_version",
+          notes
+        )
+      : resolvedVersion ?? "";
+  const toCmp =
+    mode === "range"
+      ? resolveAvailableVersion(
+          availableVersions,
+          options.to_version ?? "",
+          "to_version",
+          notes
+        )
+      : resolvedVersion ?? "";
 
   const counts: Record<Ui5ChangeType, number> = {
     FEATURE: 0,
@@ -377,9 +592,12 @@ export function filterUi5Diff(
       maxVersion = version;
     }
 
-    // Range: changes that landed AFTER from_version, up to and including to_version.
-    if (compareUi5Versions(version, fromCmp) <= 0) continue;
-    if (compareUi5Versions(version, toCmp) > 0) continue;
+    const inScope =
+      mode === "version"
+        ? compareUi5Versions(version, toCmp) === 0
+        : compareUi5Versions(version, fromCmp) > 0 &&
+          compareUi5Versions(version, toCmp) <= 0;
+    if (!inScope) continue;
 
     versionsInRange.push(version);
 
@@ -414,20 +632,24 @@ export function filterUi5Diff(
 
   // Surface out-of-range hints so the caller (LLM or human) knows when the
   // requested range falls outside what the dataset actually carries.
-  if (minVersion && compareUi5Versions(options.from_version, minVersion) < 0) {
+  if (mode === "range" && minVersion && compareUi5Versions(fromCmp, minVersion) < 0) {
     notes.push(
-      `from_version ${options.from_version} predates the oldest version in the dataset (${minVersion}); the lower bound is effectively that version.`
+      `from_version ${fromCmp} predates the oldest version in the dataset (${minVersion}); the lower bound is effectively that version.`
     );
   }
-  if (maxVersion && compareUi5Versions(options.to_version, maxVersion) > 0) {
+  if (maxVersion && compareUi5Versions(toCmp, maxVersion) > 0) {
     notes.push(
-      `to_version ${options.to_version} is newer than the newest version in the dataset (${maxVersion}); upgrade to a future release isn't covered yet.`
+      `${mode === "version" ? "version" : "to_version"} ${toCmp} is newer than the newest version in the dataset (${maxVersion}); upgrade to a future release isn't covered yet.`
     );
   }
   if (versionsInRange.length === 0) {
-    notes.push(
-      `No versions matched the range (${options.from_version}, ${options.to_version}]. Tip: use the full x.y.z form — "1.120" matches "1.120.0" exactly and will miss "1.120.5".`
-    );
+    if (mode === "version") {
+      notes.push(`No exact version block matched ${toCmp}.`);
+    } else {
+      notes.push(
+        `No versions matched the range (${fromCmp}, ${toCmp}]. Tip: unavailable patch versions are resolved to the nearest lower available version with the same major.minor, matching the web app.`
+      );
+    }
   }
   if (Array.isArray(options.types) && requestedTypes.length === 0 && options.types.length > 0) {
     notes.push(
@@ -436,21 +658,45 @@ export function filterUi5Diff(
   }
 
   const totalEntries = counts.FEATURE + counts.FIX + counts.DEPRECATED;
+  const whatsNewResult = filterWhatsNew(
+    whatsNew,
+    options,
+    mode,
+    fromCmp,
+    toCmp,
+    limit
+  );
 
   return {
+    mode,
     library,
-    from_version: options.from_version,
-    to_version: options.to_version,
+    from_version: fromCmp,
+    to_version: toCmp,
+    ...(mode === "version" ? { version: toCmp } : {}),
     versionsInRange,
     counts,
     totalEntries,
     truncated: totalEntries > entries.length,
     entries,
+    whatsNewEntries: whatsNewResult.entries,
+    whatsNewTotalEntries: whatsNewResult.totalEntries,
+    whatsNewTruncated: whatsNewResult.truncated,
     sourceUrl: "https://ui5-lib-diff.marianzeis.de/",
     meta: {
       availableVersions: data.length,
       minVersion,
       maxVersion,
+      whatsNewAvailable: whatsNew.length,
+      requested: {
+        ...(requestedVersion ? { version: requestedVersion } : {}),
+        ...(options.from_version ? { from_version: options.from_version } : {}),
+        ...(options.to_version ? { to_version: options.to_version } : {}),
+      },
+      resolved: {
+        ...(mode === "version"
+          ? { version: toCmp }
+          : { from_version: fromCmp, to_version: toCmp }),
+      },
       ...(notes.length > 0 ? { notes } : {}),
     },
   };
@@ -463,24 +709,37 @@ export function filterUi5Diff(
 export async function getUi5VersionDiff(
   options: Ui5VersionDiffOptions
 ): Promise<Ui5VersionDiffResult> {
-  if (!options.from_version || !options.to_version) {
-    throw new Error("ui5_version_diff requires from_version and to_version");
-  }
-  // Strict <: from == to is a degenerate range that, given the
-  // exclusive-from / inclusive-to semantics, would silently return zero
-  // entries. Surface that as an error so the caller can fix the inputs.
-  if (compareUi5Versions(options.from_version, options.to_version) >= 0) {
+  const requestedSingleVersion =
+    options.version ??
+    (!options.to_version && options.from_version ? options.from_version : undefined) ??
+    (!options.from_version && options.to_version ? options.to_version : undefined);
+
+  if (!requestedSingleVersion && (!options.from_version || !options.to_version)) {
     throw new Error(
-      `from_version (${options.from_version}) must be strictly less than to_version (${options.to_version}). The range is exclusive at from_version and inclusive at to_version, so from == to has no changes by definition.`
+      "ui5_version_diff requires either version, or from_version and to_version"
+    );
+  }
+  if (
+    !requestedSingleVersion &&
+    options.from_version &&
+    options.to_version &&
+    compareUi5Versions(options.from_version, options.to_version) > 0
+  ) {
+    throw new Error(
+      `from_version (${options.from_version}) must be less than or equal to to_version (${options.to_version}). Use version="${options.from_version}" to inspect a single release.`
     );
   }
 
   const library = options.library ?? "SAPUI5";
   const loaded = await loadConsolidated(library);
-  const result = filterUi5Diff(loaded.data, { ...options, library });
+  const result = filterUi5Diff(loaded.data, { ...options, library }, loaded.whatsNew);
   return {
     ...result,
-    sourceUrl: buildUi5LibDiffAppUrl({ ...options, library }),
+    sourceUrl: buildUi5LibDiffAppUrl({
+      library,
+      from_version: result.from_version,
+      to_version: result.to_version,
+    }),
     meta: {
       ...result.meta,
       sourceDataPath: loaded.sourceDataPath,
@@ -498,7 +757,7 @@ export async function prefetchUi5LibDiff(): Promise<void> {
     const bundle = await readLocalBundle();
     cacheLoadedBundle(bundle);
     console.log(
-      `✅ [ui5VersionDiff] Loaded local UI5 diff bundle from ${bundle.sourceDataPath} (${bundle.datasets.SAPUI5.length} SAPUI5 versions, ${bundle.datasets.OpenUI5.length} OpenUI5 versions)`
+      `✅ [ui5VersionDiff] Loaded local UI5 diff bundle from ${bundle.sourceDataPath} (${bundle.datasets.SAPUI5.length} SAPUI5 versions, ${bundle.datasets.OpenUI5.length} OpenUI5 versions, ${bundle.whatsNew.length} What's New entries)`
     );
   } catch (err) {
     console.error(

--- a/src/lib/ui5LibDiff/ui5VersionDiff.ts
+++ b/src/lib/ui5LibDiff/ui5VersionDiff.ts
@@ -2,13 +2,14 @@
 // Fetch, cache, and filter the consolidated change data published by
 // https://github.com/marianfoo/ui5-lib-diff (powering https://ui5-lib-diff.marianzeis.de/).
 //
-// Each consolidated JSON is an array of version blocks:
+// The preferred static API is a one-file bundle:
+//   { schemaVersion, generatedAt, datasets: { SAPUI5: [...], OpenUI5: [...] } }
+// Each dataset is an array of version blocks:
 //   [{ version, date, libraries: [{ library, changes: [{ type, text, commit_url?, id? }] }] }]
-// The data covers both SAPUI5 and OpenUI5; we expose a single tool with a
-// `library` selector so callers can pick the flavour matching their project.
+// Runtime access is local-only; setup/download scripts are responsible for
+// refreshing the bundle before the server starts.
 
-import { readFile, writeFile, mkdir } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { readFile } from "node:fs/promises";
 import { TtlCache } from "../softwareHeroes/core.js";
 import { CONFIG } from "../config.js";
 
@@ -39,6 +40,13 @@ interface RawVersionBlock {
   version: string;
   date?: string;
   libraries: RawLibraryBlock[];
+}
+
+/** One-file bundle published by ui5-lib-diff for local-first consumers. */
+interface RawBundle {
+  schemaVersion?: number;
+  generatedAt?: string;
+  datasets?: Partial<Record<Ui5LibDiffLibrary, RawVersionBlock[]>>;
 }
 
 /** A single filtered change emitted by the tool. */
@@ -80,6 +88,8 @@ export interface Ui5VersionDiffResult {
     availableVersions: number;
     minVersion?: string;
     maxVersion?: string;
+    sourceDataPath?: string;
+    cacheSource?: "disk";
     /** Soft signals for the caller: out-of-range hints, coercion notes, etc. */
     notes?: string[];
   };
@@ -89,26 +99,47 @@ export interface Ui5VersionDiffResult {
 // Configuration
 // ---------------------------------------------------------------------------
 
-const SOURCE_BASE_URL =
-  "https://raw.githubusercontent.com/marianfoo/ui5-lib-diff/main/de.marianzeis.ui5libdiff/webapp/data";
-
-const FILE_NAMES: Record<Ui5LibDiffLibrary, string> = {
-  SAPUI5: "consolidatedSAPUI5.json",
-  OpenUI5: "consolidatedOpenUI5.json",
-};
-
+const BUNDLE_CACHE_KEY = "all-changes";
+const UI5_LIBRARIES: Ui5LibDiffLibrary[] = ["SAPUI5", "OpenUI5"];
 const DEFAULT_LIMIT = 200;
 const MAX_LIMIT = 1000;
 
+interface LoadedDataset {
+  data: RawVersionBlock[];
+  sourceDataPath: string;
+  cacheSource: "disk";
+}
+
+interface LoadedBundle {
+  datasets: Record<Ui5LibDiffLibrary, RawVersionBlock[]>;
+  sourceDataPath: string;
+  cacheSource: "disk";
+  generatedAt?: string;
+}
+
 // 24h memory cache, shared across calls within a single process.
-const memoryCache = new TtlCache<RawVersionBlock[]>(
+const memoryCache = new TtlCache<LoadedDataset>(
+  CONFIG.UI5_LIB_DIFF_CACHE_TTL_MS
+);
+const bundleMemoryCache = new TtlCache<LoadedBundle>(
   CONFIG.UI5_LIB_DIFF_CACHE_TTL_MS
 );
 
-function diskCachePath(library: Ui5LibDiffLibrary): string {
-  // CWD-relative by default (see CONFIG.UI5_LIB_DIFF_CACHE_DIR). The disk
-  // cache is wiped whenever `dist/` is removed, e.g. during a full build.
-  return join(CONFIG.UI5_LIB_DIFF_CACHE_DIR, FILE_NAMES[library]);
+function normalizeBaseUrl(url: string): string {
+  return url.replace(/\/+$/, "");
+}
+
+function buildUi5LibDiffAppUrl(options: Ui5VersionDiffOptions): string {
+  const params = new URLSearchParams({
+    versionFrom: options.from_version,
+    versionTo: options.to_version,
+    ui5Type: options.library ?? "SAPUI5",
+  });
+  return `${normalizeBaseUrl(CONFIG.UI5_LIB_DIFF_APP_BASE_URL)}/?${params.toString()}`;
+}
+
+function localBundlePath(): string {
+  return CONFIG.UI5_LIB_DIFF_BUNDLE_PATH;
 }
 
 // ---------------------------------------------------------------------------
@@ -148,7 +179,7 @@ const CANONICAL_TYPES: ReadonlySet<Ui5ChangeType> = new Set([
 
 /**
  * The upstream data is canonicalized at the source as of
- * https://github.com/marianfoo/ui5-lib-diff (parseChanges.js#normalizeType):
+ * https://github.com/marianfoo/ui5-lib-diff (lib/ui5DiffData.js#normalizeChangeType):
  * every `type` is one of "FEATURE" | "FIX" | "DEPRECATED" and the historic
  * casing variants ("Feature", "feature", "Fix") plus internal/legacy
  * markers ("INTERNAL", the "INETRNAL" typo, "[INTERNAL] ALP", "LEGACY")
@@ -202,91 +233,85 @@ function reportNonCanonicalDrift(
 }
 
 // ---------------------------------------------------------------------------
-// Data loading (memory -> network -> disk fallback)
+// Data loading (memory -> local all-changes bundle)
 // ---------------------------------------------------------------------------
 
-async function writeDiskCache(
-  library: Ui5LibDiffLibrary,
-  data: RawVersionBlock[]
-): Promise<void> {
-  const path = diskCachePath(library);
-  await mkdir(dirname(path), { recursive: true });
-  await writeFile(path, JSON.stringify(data), "utf-8");
+function parseBundleJson(
+  json: unknown,
+  sourceDataPath: string
+): LoadedBundle {
+  const raw = json as RawBundle | undefined;
+  const sapui5 = raw?.datasets?.SAPUI5;
+  const openui5 = raw?.datasets?.OpenUI5;
+
+  if (!Array.isArray(sapui5) || !Array.isArray(openui5)) {
+    throw new Error(
+      "Expected JSON object with datasets.SAPUI5 and datasets.OpenUI5 arrays"
+    );
+  }
+
+  return {
+    datasets: {
+      SAPUI5: sapui5,
+      OpenUI5: openui5,
+    },
+    sourceDataPath,
+    cacheSource: "disk",
+    generatedAt:
+      typeof raw?.generatedAt === "string" ? raw.generatedAt : undefined,
+  };
 }
 
-async function readDiskCache(
-  library: Ui5LibDiffLibrary
-): Promise<RawVersionBlock[] | undefined> {
-  try {
-    const raw = await readFile(diskCachePath(library), "utf-8");
-    return JSON.parse(raw) as RawVersionBlock[];
-  } catch {
-    return undefined;
+function cacheLoadedBundle(bundle: LoadedBundle, reportDrift = true): void {
+  bundleMemoryCache.set(BUNDLE_CACHE_KEY, bundle);
+  for (const library of UI5_LIBRARIES) {
+    const data = bundle.datasets[library];
+    memoryCache.set(library, {
+      data,
+      sourceDataPath: bundle.sourceDataPath,
+      cacheSource: bundle.cacheSource,
+    });
+    if (reportDrift) {
+      reportNonCanonicalDrift(library, data);
+    }
   }
 }
 
-async function fetchConsolidated(
-  library: Ui5LibDiffLibrary
-): Promise<RawVersionBlock[]> {
-  const url = `${SOURCE_BASE_URL}/${FILE_NAMES[library]}`;
-  const controller = new AbortController();
-  const timeout = setTimeout(
-    () => controller.abort(),
-    CONFIG.UI5_LIB_DIFF_TIMEOUT_MS
-  );
-  try {
-    const response = await fetch(url, { signal: controller.signal });
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status} for ${url}`);
-    }
-    const json = (await response.json()) as RawVersionBlock[];
-    if (!Array.isArray(json)) {
-      throw new Error(`Expected JSON array from ${url}`);
-    }
-    return json;
-  } finally {
-    clearTimeout(timeout);
-  }
+async function readLocalBundle(): Promise<LoadedBundle> {
+  const path = localBundlePath();
+  const raw = await readFile(path, "utf-8");
+  return parseBundleJson(JSON.parse(raw), path);
 }
 
 async function loadConsolidated(
   library: Ui5LibDiffLibrary
-): Promise<RawVersionBlock[]> {
+): Promise<LoadedDataset> {
   const cached = memoryCache.get(library);
   if (cached) return cached;
 
+  const cachedBundle = bundleMemoryCache.get(BUNDLE_CACHE_KEY);
+  if (cachedBundle) {
+    cacheLoadedBundle(cachedBundle, false);
+    const hydrated = memoryCache.get(library);
+    if (hydrated) return hydrated;
+  }
+
   try {
-    const fresh = await fetchConsolidated(library);
-    memoryCache.set(library, fresh);
-    reportNonCanonicalDrift(library, fresh);
-    // Fire-and-forget on the request hot path: the caller already has the
-    // data, the disk write is just a future-restart optimization. The
-    // prefetch path below awaits this same write because there is no
-    // caller waiting.
-    writeDiskCache(library, fresh).catch((err) =>
-      console.error(
-        `⚠️ [ui5VersionDiff] Failed to persist ${library} disk cache:`,
-        err
-      )
-    );
-    return fresh;
-  } catch (networkErr) {
-    console.error(
-      `⚠️ [ui5VersionDiff] Network fetch failed for ${library}, trying disk cache:`,
-      networkErr
-    );
-    const disk = await readDiskCache(library);
-    if (disk) {
-      memoryCache.set(library, disk);
-      reportNonCanonicalDrift(library, disk);
-      return disk;
-    }
+    const bundle = await readLocalBundle();
+    cacheLoadedBundle(bundle);
+    const loadedFromBundle = memoryCache.get(library);
+    if (loadedFromBundle) return loadedFromBundle;
+  } catch (err) {
     throw new Error(
-      `ui5-lib-diff data unavailable for ${library}: network failed and no disk cache exists (${
-        networkErr instanceof Error ? networkErr.message : String(networkErr)
+      `ui5-lib-diff local bundle unavailable at ${localBundlePath()}. Run npm run download:ui5-lib-diff or point UI5_LIB_DIFF_BUNDLE_PATH to a local all-changes.json file. Details: ${
+        err instanceof Error ? err.message : String(err)
       })`
     );
   }
+
+  throw new Error(
+    `ui5-lib-diff local bundle at ${localBundlePath()} did not contain ${library}`
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -451,47 +476,49 @@ export async function getUi5VersionDiff(
   }
 
   const library = options.library ?? "SAPUI5";
-  const data = await loadConsolidated(library);
-  return filterUi5Diff(data, { ...options, library });
+  const loaded = await loadConsolidated(library);
+  const result = filterUi5Diff(loaded.data, { ...options, library });
+  return {
+    ...result,
+    sourceUrl: buildUi5LibDiffAppUrl({ ...options, library }),
+    meta: {
+      ...result.meta,
+      sourceDataPath: loaded.sourceDataPath,
+      cacheSource: loaded.cacheSource,
+    },
+  };
 }
 
 // ---------------------------------------------------------------------------
-// Startup prefetch (fire-and-forget, never throws)
+// Startup local bundle warmup (never throws)
 // ---------------------------------------------------------------------------
 
 export async function prefetchUi5LibDiff(): Promise<void> {
-  await Promise.all(
-    (Object.keys(FILE_NAMES) as Ui5LibDiffLibrary[]).map(async (library) => {
-      try {
-        const data = await fetchConsolidated(library);
-        memoryCache.set(library, data);
-        reportNonCanonicalDrift(library, data);
-        await writeDiskCache(library, data);
-        console.log(
-          `✅ [ui5VersionDiff] Prefetched ${library}: ${data.length} versions`
-        );
-      } catch (err) {
-        console.error(
-          `⚠️ [ui5VersionDiff] Prefetch failed for ${library}:`,
-          err
-        );
-        const disk = await readDiskCache(library);
-        if (disk) {
-          memoryCache.set(library, disk);
-          reportNonCanonicalDrift(library, disk);
-          console.log(
-            `📂 [ui5VersionDiff] Loaded ${library} from disk cache: ${disk.length} versions`
-          );
-        }
-      }
-    })
-  );
+  try {
+    const bundle = await readLocalBundle();
+    cacheLoadedBundle(bundle);
+    console.log(
+      `✅ [ui5VersionDiff] Loaded local UI5 diff bundle from ${bundle.sourceDataPath} (${bundle.datasets.SAPUI5.length} SAPUI5 versions, ${bundle.datasets.OpenUI5.length} OpenUI5 versions)`
+    );
+  } catch (err) {
+    console.error(
+      `⚠️ [ui5VersionDiff] Local UI5 diff bundle unavailable at ${localBundlePath()}. Run npm run download:ui5-lib-diff before using ui5_version_diff:`,
+      err
+    );
+  }
 }
 
 export function getUi5LibDiffCacheStats() {
   return {
+    bundle: bundleMemoryCache.has(BUNDLE_CACHE_KEY),
     SAPUI5: memoryCache.has("SAPUI5"),
     OpenUI5: memoryCache.has("OpenUI5"),
+    bundlePath: localBundlePath(),
     ttlMs: CONFIG.UI5_LIB_DIFF_CACHE_TTL_MS,
   };
+}
+
+export function clearUi5LibDiffCachesForTests(): void {
+  memoryCache.clear();
+  bundleMemoryCache.clear();
 }

--- a/src/lib/ui5LibDiff/ui5VersionDiff.ts
+++ b/src/lib/ui5LibDiff/ui5VersionDiff.ts
@@ -1,0 +1,398 @@
+// UI5 Version Diff
+// Fetch, cache, and filter the consolidated change data published by
+// https://github.com/marianfoo/ui5-lib-diff (powering https://ui5-lib-diff.marianzeis.de/).
+//
+// Each consolidated JSON is an array of version blocks:
+//   [{ version, date, libraries: [{ library, changes: [{ type, text, commit_url?, id? }] }] }]
+// The data covers both SAPUI5 and OpenUI5; we expose a single tool with a
+// `library` selector so callers can pick the flavour matching their project.
+
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { dirname } from "node:path";
+import { TtlCache } from "../softwareHeroes/core.js";
+import { CONFIG } from "../config.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type Ui5LibDiffLibrary = "SAPUI5" | "OpenUI5";
+
+export type Ui5ChangeType = "FEATURE" | "FIX" | "DEPRECATED";
+
+/** Raw change record as published by ui5-lib-diff. */
+interface RawChange {
+  type: string;
+  text: string;
+  commit_url?: string;
+  id?: string;
+}
+
+/** Raw library block inside a version. */
+interface RawLibraryBlock {
+  library: string;
+  changes: RawChange[];
+}
+
+/** Raw version block as published by ui5-lib-diff. */
+interface RawVersionBlock {
+  version: string;
+  date?: string;
+  libraries: RawLibraryBlock[];
+}
+
+/** A single filtered change emitted by the tool. */
+export interface Ui5ChangeEntry {
+  version: string;
+  date?: string;
+  library: string;
+  type: Ui5ChangeType;
+  text: string;
+  commit_url?: string;
+}
+
+export interface Ui5VersionDiffOptions {
+  library?: Ui5LibDiffLibrary;
+  from_version: string;
+  to_version: string;
+  /** Filter to specific change types. Defaults to all three. */
+  types?: Ui5ChangeType[];
+  /** Substring filter on the UI5 library name (case-insensitive, e.g. "sap.m"). */
+  ui5_library?: string;
+  /** Substring filter on the change text (case-insensitive). */
+  query?: string;
+  /** Maximum entries to return. Default: 200, max: 1000. */
+  limit?: number;
+}
+
+export interface Ui5VersionDiffResult {
+  library: Ui5LibDiffLibrary;
+  from_version: string;
+  to_version: string;
+  /** Versions that fall in the requested range (exclusive of from, inclusive of to). */
+  versionsInRange: string[];
+  counts: Record<Ui5ChangeType, number>;
+  totalEntries: number;
+  truncated: boolean;
+  entries: Ui5ChangeEntry[];
+  sourceUrl: string;
+  meta: {
+    availableVersions: number;
+    minVersion?: string;
+    maxVersion?: string;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+const SOURCE_BASE_URL =
+  "https://raw.githubusercontent.com/marianfoo/ui5-lib-diff/main/de.marianzeis.ui5libdiff/webapp/data";
+
+const FILE_NAMES: Record<Ui5LibDiffLibrary, string> = {
+  SAPUI5: "consolidatedSAPUI5.json",
+  OpenUI5: "consolidatedOpenUI5.json",
+};
+
+const DEFAULT_LIMIT = 200;
+const MAX_LIMIT = 1000;
+
+// 24h memory cache, shared across calls within a single process.
+const memoryCache = new TtlCache<RawVersionBlock[]>(
+  CONFIG.UI5_LIB_DIFF_CACHE_TTL_MS
+);
+
+function diskCachePath(library: Ui5LibDiffLibrary): string {
+  return CONFIG.UI5_LIB_DIFF_CACHE_DIR + `/${FILE_NAMES[library]}`;
+}
+
+// ---------------------------------------------------------------------------
+// Version parsing & comparison
+// ---------------------------------------------------------------------------
+
+/** Parse "1.108.0" -> [1, 108, 0]. Missing parts default to 0. */
+export function parseUi5Version(v: string): [number, number, number] {
+  const trimmed = (v ?? "").trim().replace(/^v/i, "");
+  const parts = trimmed.split(".").slice(0, 3);
+  const nums = parts.map((p) => {
+    const n = parseInt(p.replace(/[^0-9]/g, ""), 10);
+    return Number.isFinite(n) ? n : 0;
+  });
+  return [nums[0] ?? 0, nums[1] ?? 0, nums[2] ?? 0];
+}
+
+/** Returns negative / 0 / positive like the usual comparator contract. */
+export function compareUi5Versions(a: string, b: string): number {
+  const aa = parseUi5Version(a);
+  const bb = parseUi5Version(b);
+  for (let i = 0; i < 3; i++) {
+    if (aa[i] !== bb[i]) return aa[i] - bb[i];
+  }
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Type normalization
+// ---------------------------------------------------------------------------
+
+/**
+ * The upstream data mixes casing and contains internal/legacy markers
+ * ("Feature", "feature", "INETRNAL" typo, "[INTERNAL] ALP", "LEGACY").
+ * We only expose the three categories users actually care about.
+ */
+export function normalizeChangeType(raw: string): Ui5ChangeType | null {
+  const t = (raw ?? "").trim().toUpperCase();
+  if (t === "FEATURE") return "FEATURE";
+  if (t === "FIX") return "FIX";
+  if (t === "DEPRECATED") return "DEPRECATED";
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Data loading (memory -> network -> disk fallback)
+// ---------------------------------------------------------------------------
+
+async function writeDiskCache(
+  library: Ui5LibDiffLibrary,
+  data: RawVersionBlock[]
+): Promise<void> {
+  const path = diskCachePath(library);
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, JSON.stringify(data), "utf-8");
+}
+
+async function readDiskCache(
+  library: Ui5LibDiffLibrary
+): Promise<RawVersionBlock[] | undefined> {
+  try {
+    const raw = await readFile(diskCachePath(library), "utf-8");
+    return JSON.parse(raw) as RawVersionBlock[];
+  } catch {
+    return undefined;
+  }
+}
+
+async function fetchConsolidated(
+  library: Ui5LibDiffLibrary
+): Promise<RawVersionBlock[]> {
+  const url = `${SOURCE_BASE_URL}/${FILE_NAMES[library]}`;
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () => controller.abort(),
+    CONFIG.UI5_LIB_DIFF_TIMEOUT_MS
+  );
+  try {
+    const response = await fetch(url, { signal: controller.signal });
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status} for ${url}`);
+    }
+    const json = (await response.json()) as RawVersionBlock[];
+    if (!Array.isArray(json)) {
+      throw new Error(`Expected JSON array from ${url}`);
+    }
+    return json;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function loadConsolidated(
+  library: Ui5LibDiffLibrary
+): Promise<RawVersionBlock[]> {
+  const cached = memoryCache.get(library);
+  if (cached) return cached;
+
+  try {
+    const fresh = await fetchConsolidated(library);
+    memoryCache.set(library, fresh);
+    writeDiskCache(library, fresh).catch((err) =>
+      console.error(
+        `⚠️ [ui5VersionDiff] Failed to persist ${library} disk cache:`,
+        err
+      )
+    );
+    return fresh;
+  } catch (networkErr) {
+    console.error(
+      `⚠️ [ui5VersionDiff] Network fetch failed for ${library}, trying disk cache:`,
+      networkErr
+    );
+    const disk = await readDiskCache(library);
+    if (disk) {
+      memoryCache.set(library, disk);
+      return disk;
+    }
+    throw new Error(
+      `ui5-lib-diff data unavailable for ${library}: network failed and no disk cache exists (${
+        networkErr instanceof Error ? networkErr.message : String(networkErr)
+      })`
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Filtering
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply the diff filters to an already-loaded dataset.
+ * Pure function so unit tests can drive it from fixtures.
+ */
+export function filterUi5Diff(
+  data: RawVersionBlock[],
+  options: Ui5VersionDiffOptions
+): Ui5VersionDiffResult {
+  const library = options.library ?? "SAPUI5";
+  const typesAllowed = new Set<Ui5ChangeType>(
+    options.types && options.types.length > 0
+      ? options.types
+      : ["FEATURE", "FIX", "DEPRECATED"]
+  );
+  const limit = Math.min(
+    Math.max(options.limit ?? DEFAULT_LIMIT, 1),
+    MAX_LIMIT
+  );
+  const libFilter = options.ui5_library?.toLowerCase().trim() || "";
+  const queryFilter = options.query?.toLowerCase().trim() || "";
+
+  const fromCmp = options.from_version;
+  const toCmp = options.to_version;
+
+  const counts: Record<Ui5ChangeType, number> = {
+    FEATURE: 0,
+    FIX: 0,
+    DEPRECATED: 0,
+  };
+  const entries: Ui5ChangeEntry[] = [];
+  const versionsInRange: string[] = [];
+
+  // Track dataset bounds for meta.
+  let minVersion: string | undefined;
+  let maxVersion: string | undefined;
+
+  for (const block of data) {
+    const version = block.version;
+    if (!version) continue;
+
+    if (!minVersion || compareUi5Versions(version, minVersion) < 0) {
+      minVersion = version;
+    }
+    if (!maxVersion || compareUi5Versions(version, maxVersion) > 0) {
+      maxVersion = version;
+    }
+
+    // Range: changes that landed AFTER from_version, up to and including to_version.
+    if (compareUi5Versions(version, fromCmp) <= 0) continue;
+    if (compareUi5Versions(version, toCmp) > 0) continue;
+
+    versionsInRange.push(version);
+
+    for (const libBlock of block.libraries ?? []) {
+      const libName = libBlock.library ?? "";
+      if (libFilter && !libName.toLowerCase().includes(libFilter)) continue;
+
+      for (const change of libBlock.changes ?? []) {
+        const type = normalizeChangeType(change.type);
+        if (!type || !typesAllowed.has(type)) continue;
+        const text = (change.text ?? "").trim();
+        if (queryFilter && !text.toLowerCase().includes(queryFilter)) continue;
+
+        counts[type]++;
+
+        if (entries.length < limit) {
+          entries.push({
+            version,
+            date: block.date,
+            library: libName,
+            type,
+            text,
+            commit_url: change.commit_url,
+          });
+        }
+      }
+    }
+  }
+
+  // Sort version list newest-first for display.
+  versionsInRange.sort((a, b) => compareUi5Versions(b, a));
+
+  const totalEntries = counts.FEATURE + counts.FIX + counts.DEPRECATED;
+
+  return {
+    library,
+    from_version: options.from_version,
+    to_version: options.to_version,
+    versionsInRange,
+    counts,
+    totalEntries,
+    truncated: totalEntries > entries.length,
+    entries,
+    sourceUrl: "https://ui5-lib-diff.marianzeis.de/",
+    meta: {
+      availableVersions: data.length,
+      minVersion,
+      maxVersion,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export async function getUi5VersionDiff(
+  options: Ui5VersionDiffOptions
+): Promise<Ui5VersionDiffResult> {
+  if (!options.from_version || !options.to_version) {
+    throw new Error("ui5_version_diff requires from_version and to_version");
+  }
+  if (compareUi5Versions(options.from_version, options.to_version) > 0) {
+    throw new Error(
+      `from_version (${options.from_version}) must be <= to_version (${options.to_version})`
+    );
+  }
+
+  const library = options.library ?? "SAPUI5";
+  const data = await loadConsolidated(library);
+  return filterUi5Diff(data, { ...options, library });
+}
+
+// ---------------------------------------------------------------------------
+// Startup prefetch (fire-and-forget, never throws)
+// ---------------------------------------------------------------------------
+
+export async function prefetchUi5LibDiff(): Promise<void> {
+  await Promise.all(
+    (Object.keys(FILE_NAMES) as Ui5LibDiffLibrary[]).map(async (library) => {
+      try {
+        const data = await fetchConsolidated(library);
+        memoryCache.set(library, data);
+        await writeDiskCache(library, data);
+        console.log(
+          `✅ [ui5VersionDiff] Prefetched ${library}: ${data.length} versions`
+        );
+      } catch (err) {
+        console.error(
+          `⚠️ [ui5VersionDiff] Prefetch failed for ${library}:`,
+          err
+        );
+        const disk = await readDiskCache(library);
+        if (disk) {
+          memoryCache.set(library, disk);
+          console.log(
+            `📂 [ui5VersionDiff] Loaded ${library} from disk cache: ${disk.length} versions`
+          );
+        }
+      }
+    })
+  );
+}
+
+export function getUi5LibDiffCacheStats() {
+  return {
+    SAPUI5: memoryCache.has("SAPUI5"),
+    OpenUI5: memoryCache.has("OpenUI5"),
+    ttlMs: CONFIG.UI5_LIB_DIFF_CACHE_TTL_MS,
+  };
+}

--- a/src/lib/ui5LibDiff/ui5VersionDiff.ts
+++ b/src/lib/ui5LibDiff/ui5VersionDiff.ts
@@ -84,8 +84,6 @@ export interface Ui5VersionDiffOptions {
   ui5_library?: string;
   /** Substring filter on the change text (case-insensitive). */
   query?: string;
-  /** Maximum entries to return. Default: 200, max: 1000. */
-  limit?: number;
 }
 
 export interface Ui5WhatsNewEntry {
@@ -110,16 +108,15 @@ export interface Ui5VersionDiffResult {
   versionsInRange: string[];
   counts: Record<Ui5ChangeType, number>;
   totalEntries: number;
-  truncated: boolean;
   entries: Ui5ChangeEntry[];
   whatsNewEntries: Ui5WhatsNewEntry[];
   whatsNewTotalEntries: number;
-  whatsNewTruncated: boolean;
   sourceUrl: string;
   meta: {
     availableVersions: number;
     minVersion?: string;
     maxVersion?: string;
+    generatedAt?: string;
     sourceDataPath?: string;
     cacheSource?: "disk";
     requested?: {
@@ -144,14 +141,13 @@ export interface Ui5VersionDiffResult {
 
 const BUNDLE_CACHE_KEY = "all-changes";
 const UI5_LIBRARIES: Ui5LibDiffLibrary[] = ["SAPUI5", "OpenUI5"];
-const DEFAULT_LIMIT = 200;
-const MAX_LIMIT = 1000;
 
 interface LoadedDataset {
   data: RawVersionBlock[];
   whatsNew: RawWhatsNewEntry[];
   sourceDataPath: string;
   cacheSource: "disk";
+  generatedAt?: string;
 }
 
 interface LoadedBundle {
@@ -346,6 +342,7 @@ function cacheLoadedBundle(bundle: LoadedBundle, reportDrift = true): void {
       whatsNew: bundle.whatsNew,
       sourceDataPath: bundle.sourceDataPath,
       cacheSource: bundle.cacheSource,
+      generatedAt: bundle.generatedAt,
     });
     if (reportDrift) {
       reportNonCanonicalDrift(library, data);
@@ -379,7 +376,7 @@ async function loadConsolidated(
     if (loadedFromBundle) return loadedFromBundle;
   } catch (err) {
     throw new Error(
-      `ui5-lib-diff local bundle unavailable at ${localBundlePath()}. Run npm run download:ui5-lib-diff or point UI5_LIB_DIFF_BUNDLE_PATH to a local all-changes.json file. Details: ${
+      `ui5-lib-diff local bundle unavailable at ${localBundlePath()}. Refresh the bundle during setup with npm run download:ui5-lib-diff or point UI5_LIB_DIFF_BUNDLE_PATH to a local all-changes.json file. Details: ${
         err instanceof Error ? err.message : String(err)
       })`
     );
@@ -388,6 +385,40 @@ async function loadConsolidated(
   throw new Error(
     `ui5-lib-diff local bundle at ${localBundlePath()} did not contain ${library}`
   );
+}
+
+function requestedVersionCandidates(options: Ui5VersionDiffOptions): string[] {
+  return [options.version, options.from_version, options.to_version].filter(
+    (version): version is string => Boolean(version)
+  );
+}
+
+function shouldReloadLocalBundle(
+  data: RawVersionBlock[],
+  options: Ui5VersionDiffOptions
+): boolean {
+  const availableVersions = new Set(
+    data.map((block) => block.version).filter(Boolean)
+  );
+  return requestedVersionCandidates(options).some(
+    (version) => !availableVersions.has(version)
+  );
+}
+
+async function reloadConsolidatedFromDisk(
+  library: Ui5LibDiffLibrary
+): Promise<LoadedDataset | null> {
+  try {
+    const bundle = await readLocalBundle();
+    cacheLoadedBundle(bundle);
+    return memoryCache.get(library) ?? null;
+  } catch (err) {
+    console.warn(
+      `[ui5VersionDiff] Could not refresh local UI5 diff bundle from ${localBundlePath()}; using cached data:`,
+      err
+    );
+    return null;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -412,13 +443,13 @@ function resolveAvailableVersion(
 
   if (nearest) {
     notes.push(
-      `${label} ${requested} is not available; using nearest available ${requestedMinor}.x version ${nearest}.`
+      `${label} ${requested} is not available in the local bundle; using nearest available ${requestedMinor}.x version ${nearest}. If you expected a newer release, refresh the bundle during setup.`
     );
     return nearest;
   }
 
   notes.push(
-    `${label} ${requested} is not available and no ${requestedMinor}.x version exists in the dataset.`
+    `${label} ${requested} is not available in the local bundle and no ${requestedMinor}.x version exists. The runtime is local-only and will not fetch newer data; refresh the bundle during setup.`
   );
   return requested;
 }
@@ -434,12 +465,10 @@ function filterWhatsNew(
   options: Ui5VersionDiffOptions,
   mode: "range" | "version",
   fromVersion: string,
-  toVersion: string,
-  limit: number
+  toVersion: string
 ): {
   entries: Ui5WhatsNewEntry[];
   totalEntries: number;
-  truncated: boolean;
 } {
   const queryFilter = options.query?.toLowerCase().trim() || "";
   const allowedMinorKeys = new Set<string>();
@@ -475,7 +504,7 @@ function filterWhatsNew(
     return true;
   });
 
-  const entries = matching.slice(0, limit).map((item) => ({
+  const entries = matching.map((item) => ({
     version: item.Version ?? "",
     title: stripHtml(item.Title ?? ""),
     description: stripHtml(item.Description ?? ""),
@@ -490,7 +519,6 @@ function filterWhatsNew(
   return {
     entries,
     totalEntries: matching.length,
-    truncated: matching.length > entries.length,
   };
 }
 
@@ -532,10 +560,6 @@ export function filterUi5Diff(
       : ["FEATURE", "FIX", "DEPRECATED"]
   );
 
-  const limit = Math.min(
-    Math.max(Math.floor(options.limit ?? DEFAULT_LIMIT), 1),
-    MAX_LIMIT
-  );
   const libFilter = options.ui5_library?.toLowerCase().trim() || "";
   const queryFilter = options.query?.toLowerCase().trim() || "";
   const availableVersions = data
@@ -613,16 +637,14 @@ export function filterUi5Diff(
 
         counts[type]++;
 
-        if (entries.length < limit) {
-          entries.push({
-            version,
-            date: block.date,
-            library: libName,
-            type,
-            text,
-            commit_url: change.commit_url,
-          });
-        }
+        entries.push({
+          version,
+          date: block.date,
+          library: libName,
+          type,
+          text,
+          commit_url: change.commit_url,
+        });
       }
     }
   }
@@ -639,7 +661,7 @@ export function filterUi5Diff(
   }
   if (maxVersion && compareUi5Versions(toCmp, maxVersion) > 0) {
     notes.push(
-      `${mode === "version" ? "version" : "to_version"} ${toCmp} is newer than the newest version in the dataset (${maxVersion}); upgrade to a future release isn't covered yet.`
+      `${mode === "version" ? "version" : "to_version"} ${toCmp} is newer than the newest version in the local bundle (${maxVersion}). The runtime is local-only and will not fetch newer data; refresh the bundle during setup.`
     );
   }
   if (versionsInRange.length === 0) {
@@ -663,8 +685,7 @@ export function filterUi5Diff(
     options,
     mode,
     fromCmp,
-    toCmp,
-    limit
+    toCmp
   );
 
   return {
@@ -676,11 +697,9 @@ export function filterUi5Diff(
     versionsInRange,
     counts,
     totalEntries,
-    truncated: totalEntries > entries.length,
     entries,
     whatsNewEntries: whatsNewResult.entries,
     whatsNewTotalEntries: whatsNewResult.totalEntries,
-    whatsNewTruncated: whatsNewResult.truncated,
     sourceUrl: "https://ui5-lib-diff.marianzeis.de/",
     meta: {
       availableVersions: data.length,
@@ -731,7 +750,10 @@ export async function getUi5VersionDiff(
   }
 
   const library = options.library ?? "SAPUI5";
-  const loaded = await loadConsolidated(library);
+  let loaded = await loadConsolidated(library);
+  if (shouldReloadLocalBundle(loaded.data, options)) {
+    loaded = (await reloadConsolidatedFromDisk(library)) ?? loaded;
+  }
   const result = filterUi5Diff(loaded.data, { ...options, library }, loaded.whatsNew);
   return {
     ...result,
@@ -744,6 +766,7 @@ export async function getUi5VersionDiff(
       ...result.meta,
       sourceDataPath: loaded.sourceDataPath,
       cacheSource: loaded.cacheSource,
+      generatedAt: loaded.generatedAt,
     },
   };
 }
@@ -761,7 +784,7 @@ export async function prefetchUi5LibDiff(): Promise<void> {
     );
   } catch (err) {
     console.error(
-      `⚠️ [ui5VersionDiff] Local UI5 diff bundle unavailable at ${localBundlePath()}. Run npm run download:ui5-lib-diff before using ui5_version_diff:`,
+      `⚠️ [ui5VersionDiff] Local UI5 diff bundle unavailable at ${localBundlePath()}. Refresh it during setup with npm run download:ui5-lib-diff before using ui5_version_diff:`,
       err
     );
   }

--- a/src/lib/variant.ts
+++ b/src/lib/variant.ts
@@ -5,6 +5,7 @@ export interface VariantToolFlags {
   abapLint: boolean;
   abapFeatureMatrix: boolean;
   discoveryCenter: boolean;
+  ui5LibDiff: boolean;
 }
 
 export interface VariantServerIdentity {

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,9 +2,10 @@ import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { logger } from "./lib/logger.js";
 import { BaseServerHandler } from "./lib/BaseServerHandler.js";
-import { getVariantConfig } from "./lib/variant.js";
+import { getVariantConfig, isToolEnabled } from "./lib/variant.js";
 import { prefetchFeatureMatrix } from "./lib/softwareHeroes/abapFeatureMatrix.js";
 import { prefetchReleasedObjects } from "./lib/sapReleasedObjects/index.js";
+import { prefetchUi5LibDiff } from "./lib/ui5LibDiff/index.js";
 import { loadEmbeddingModel } from "./lib/embeddingSearch.js";
 
 const variant = getVariantConfig();
@@ -41,6 +42,12 @@ async function main() {
   prefetchFeatureMatrix();
   // Pre-load SAP Released Objects data (fire-and-forget, never blocks startup)
   prefetchReleasedObjects();
+  // Pre-warm the UI5 Lib Diff data when the tool is enabled (fire-and-forget)
+  if (isToolEnabled("ui5LibDiff")) {
+    prefetchUi5LibDiff().catch((err: Error) =>
+      logger.warn("ui5 lib diff prefetch failed", { error: err.message })
+    );
+  }
   // Pre-load the embedding model so the first search is fast (fire-and-forget)
   loadEmbeddingModel().catch((err: Error) =>
     logger.warn("embedding model pre-load failed", { error: err.message })

--- a/src/streamable-http-server.ts
+++ b/src/streamable-http-server.ts
@@ -8,8 +8,9 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import { logger } from "./lib/logger.js";
 import { BaseServerHandler } from "./lib/BaseServerHandler.js";
-import { getVariantConfig } from "./lib/variant.js";
+import { getVariantConfig, isToolEnabled } from "./lib/variant.js";
 import { prefetchFeatureMatrix } from "./lib/softwareHeroes/abapFeatureMatrix.js";
+import { prefetchUi5LibDiff } from "./lib/ui5LibDiff/index.js";
 import { loadEmbeddingModel } from "./lib/embeddingSearch.js";
 
 // Version will be updated by deployment script
@@ -88,6 +89,13 @@ async function main() {
 
   // Pre-warm the ABAP Feature Matrix (fire-and-forget, never blocks startup)
   prefetchFeatureMatrix();
+
+  // Pre-warm the UI5 Lib Diff data when the tool is enabled (fire-and-forget)
+  if (isToolEnabled("ui5LibDiff")) {
+    prefetchUi5LibDiff().catch((err: Error) =>
+      logger.warn("ui5 lib diff prefetch failed", { error: err.message })
+    );
+  }
 
   // Pre-load the embedding model so the first search is fast (fire-and-forget)
   loadEmbeddingModel().catch((err: Error) =>

--- a/test/fixtures/ui5-lib-diff-sample.json
+++ b/test/fixtures/ui5-lib-diff-sample.json
@@ -1,0 +1,104 @@
+[
+  {
+    "version": "1.108.0",
+    "date": "2022.10.13",
+    "libraries": [
+      {
+        "library": "sap.m",
+        "changes": [
+          {
+            "type": "FEATURE",
+            "text": "sap.m.Wizard: navigateToStep added",
+            "commit_url": "https://github.com/SAP/openui5/commit/aaa",
+            "id": "aaa"
+          },
+          {
+            "type": "INTERNAL",
+            "text": "internal noise"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "1.120.0",
+    "date": "2023.10.26",
+    "libraries": [
+      {
+        "library": "sap.m",
+        "changes": [
+          {
+            "type": "FEATURE",
+            "text": "sap.m.Input: new value help icon",
+            "commit_url": "https://github.com/SAP/openui5/commit/bbb"
+          },
+          {
+            "type": "Fix",
+            "text": "sap.m.Table: pagination scroll fix"
+          }
+        ]
+      },
+      {
+        "library": "sap.ui.core",
+        "changes": [
+          {
+            "type": "DEPRECATED",
+            "text": "sap.ui.core.ManagedObject: foo() replaced by bar()"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "1.130.0",
+    "date": "2024.09.12",
+    "libraries": [
+      {
+        "library": "sap.m",
+        "changes": [
+          {
+            "type": "feature",
+            "text": "sap.m.ObjectStatus: emptyIndicatorMode added"
+          },
+          {
+            "type": "DEPRECATED",
+            "text": "sap.m.LegacyControl: use NewControl instead"
+          }
+        ]
+      },
+      {
+        "library": "deprecated",
+        "changes": [
+          {
+            "type": "DEPRECATED",
+            "text": "[sap.ui.comp.smarttable.SmartTable#getUseExportToExcel] replaced by enableExport"
+          }
+        ]
+      },
+      {
+        "library": "sap.fe.core",
+        "changes": [
+          {
+            "type": "LEGACY",
+            "text": "legacy entry"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "version": "1.140.0",
+    "date": "2025.04.10",
+    "libraries": [
+      {
+        "library": "sap.m",
+        "changes": [
+          {
+            "type": "FEATURE",
+            "text": "sap.m.Button: badge support"
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/test/ui5-version-diff.test.ts
+++ b/test/ui5-version-diff.test.ts
@@ -43,6 +43,27 @@ function writeBundleFixture(fixtureText: string): string {
         SAPUI5: fixture,
         OpenUI5: fixture,
       },
+      whatsNew: [
+        {
+          id: 1,
+          Version: "1.130",
+          Title: "<span>sap.m.ObjectStatus</span>",
+          Description: "ObjectStatus now supports emptyIndicatorMode.",
+          Type: "Changed",
+          Action: "Info Only",
+          Category: "Control",
+          Valid_as_Of: "2024-09-12",
+          outputloio: "abc123",
+        },
+        {
+          id: 2,
+          Version: "1.140",
+          Title: "sap.m.Button",
+          Description: "Badge support.",
+          Type: "New",
+          Category: "Control",
+        },
+      ],
     }),
     "utf-8"
   );
@@ -259,26 +280,111 @@ describe("filterUi5Diff", () => {
       ])
     );
   });
+
+  it("resolves unavailable patch versions to the nearest lower available patch", () => {
+    const result = filterUi5Diff(fixture, {
+      from_version: "1.120.5",
+      to_version: "1.130.9",
+      types: ["DEPRECATED"],
+    });
+
+    expect(result.from_version).toBe("1.120.0");
+    expect(result.to_version).toBe("1.130.0");
+    expect(result.meta.notes ?? []).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("from_version 1.120.5 is not available"),
+        expect.stringContaining("to_version 1.130.9 is not available"),
+      ])
+    );
+  });
+
+  it("supports single-version requests", () => {
+    const result = filterUi5Diff(fixture, {
+      version: "1.130.0",
+    });
+
+    expect(result.mode).toBe("version");
+    expect(result.version).toBe("1.130.0");
+    expect(result.versionsInRange).toEqual(["1.130.0"]);
+    expect(result.totalEntries).toBe(3);
+  });
+
+  it("always includes What's New entries for the same range", () => {
+    const result = filterUi5Diff(
+      fixture,
+      {
+        from_version: "1.120.0",
+        to_version: "1.130.0",
+        query: "ObjectStatus",
+      },
+      [
+        {
+          id: 1,
+          Version: "1.130",
+          Title: "<span>sap.m.ObjectStatus</span>",
+          Description: "ObjectStatus now supports emptyIndicatorMode.",
+          Type: "Changed",
+          Category: "Control",
+        },
+        {
+          id: 2,
+          Version: "1.140",
+          Title: "sap.m.Button",
+          Description: "Badge support.",
+          Type: "New",
+          Category: "Control",
+        },
+      ]
+    );
+
+    expect(result.whatsNewTotalEntries).toBe(1);
+    expect(result.whatsNewEntries).toEqual([
+      expect.objectContaining({
+        version: "1.130",
+        title: "sap.m.ObjectStatus",
+        description: "ObjectStatus now supports emptyIndicatorMode.",
+      }),
+    ]);
+  });
 });
 
 describe("getUi5VersionDiff input validation", () => {
-  it("rejects from_version === to_version (degenerate range)", async () => {
-    await expect(
-      getUi5VersionDiff({ from_version: "1.130.0", to_version: "1.130.0" })
-    ).rejects.toThrow(/strictly less than/);
+  it("treats from_version === to_version as a single-version request", async () => {
+    const fixturePath = path.join(__dirname, "fixtures", "ui5-lib-diff-sample.json");
+    const fixture = fs.readFileSync(fixturePath, "utf-8");
+    const bundlePath = writeBundleFixture(fixture);
+    CONFIG.UI5_LIB_DIFF_BUNDLE_PATH = bundlePath;
+
+    const result = await getUi5VersionDiff({
+      from_version: "1.130.0",
+      to_version: "1.130.0",
+    });
+
+    expect(result.mode).toBe("version");
+    expect(result.version).toBe("1.130.0");
   });
 
   it("rejects from_version > to_version", async () => {
     await expect(
       getUi5VersionDiff({ from_version: "1.140.0", to_version: "1.108.0" })
-    ).rejects.toThrow(/strictly less than/);
+    ).rejects.toThrow(/less than or equal/);
   });
 
-  it("rejects missing parameters", async () => {
+  it("accepts a single to_version as single-version mode", async () => {
+    const fixturePath = path.join(__dirname, "fixtures", "ui5-lib-diff-sample.json");
+    const fixture = fs.readFileSync(fixturePath, "utf-8");
+    const bundlePath = writeBundleFixture(fixture);
+    CONFIG.UI5_LIB_DIFF_BUNDLE_PATH = bundlePath;
+
+    const result = await getUi5VersionDiff({ to_version: "1.130.0" });
+    expect(result.mode).toBe("version");
+    expect(result.version).toBe("1.130.0");
+  });
+
+  it("rejects completely missing parameters", async () => {
     await expect(
-      // @ts-expect-error intentionally missing required field
-      getUi5VersionDiff({ to_version: "1.130.0" })
-    ).rejects.toThrow(/requires from_version/);
+      getUi5VersionDiff({})
+    ).rejects.toThrow(/requires either version/);
   });
 
   it("reads the local all-changes bundle and reports metadata", async () => {
@@ -300,6 +406,7 @@ describe("getUi5VersionDiff input validation", () => {
     expect(fetchMock).not.toHaveBeenCalled();
     expect(result.meta.sourceDataPath).toBe(bundlePath);
     expect(result.meta.cacheSource).toBe("disk");
+    expect(result.whatsNewEntries?.length).toBe(1);
     expect(result.sourceUrl).toBe(
       "https://ui5-lib-diff.marianzeis.de/?versionFrom=1.108.0&versionTo=1.130.0&ui5Type=SAPUI5"
     );

--- a/test/ui5-version-diff.test.ts
+++ b/test/ui5-version-diff.test.ts
@@ -3,20 +3,51 @@
  * Pure unit tests against a fixture file — no network calls.
  */
 
-import { describe, it, expect, beforeAll } from "vitest";
+import { describe, it, expect, beforeAll, afterEach, vi } from "vitest";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { CONFIG } from "../dist/src/lib/config.js";
 import {
   filterUi5Diff,
   compareUi5Versions,
   parseUi5Version,
   normalizeChangeType,
   getUi5VersionDiff,
+  clearUi5LibDiffCachesForTests,
 } from "../dist/src/lib/ui5LibDiff/ui5VersionDiff.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+const originalFetch = globalThis.fetch;
+const originalBundlePath = CONFIG.UI5_LIB_DIFF_BUNDLE_PATH;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  globalThis.fetch = originalFetch;
+  CONFIG.UI5_LIB_DIFF_BUNDLE_PATH = originalBundlePath;
+  clearUi5LibDiffCachesForTests();
+});
+
+function writeBundleFixture(fixtureText: string): string {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ui5-lib-diff-"));
+  const bundlePath = path.join(tmpDir, "all-changes.json");
+  const fixture = JSON.parse(fixtureText);
+  fs.writeFileSync(
+    bundlePath,
+    JSON.stringify({
+      schemaVersion: 1,
+      generatedAt: "2026-05-20T00:00:00.000Z",
+      datasets: {
+        SAPUI5: fixture,
+        OpenUI5: fixture,
+      },
+    }),
+    "utf-8"
+  );
+  return bundlePath;
+}
 
 describe("compareUi5Versions", () => {
   it("orders versions numerically, not lexicographically", () => {
@@ -248,5 +279,75 @@ describe("getUi5VersionDiff input validation", () => {
       // @ts-expect-error intentionally missing required field
       getUi5VersionDiff({ to_version: "1.130.0" })
     ).rejects.toThrow(/requires from_version/);
+  });
+
+  it("reads the local all-changes bundle and reports metadata", async () => {
+    const fixturePath = path.join(__dirname, "fixtures", "ui5-lib-diff-sample.json");
+    const fixture = fs.readFileSync(fixturePath, "utf-8");
+    const bundlePath = writeBundleFixture(fixture);
+    CONFIG.UI5_LIB_DIFF_BUNDLE_PATH = bundlePath;
+
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as any;
+
+    const result = await getUi5VersionDiff({
+      library: "SAPUI5",
+      from_version: "1.108.0",
+      to_version: "1.130.0",
+      limit: 1,
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result.meta.sourceDataPath).toBe(bundlePath);
+    expect(result.meta.cacheSource).toBe("disk");
+    expect(result.sourceUrl).toBe(
+      "https://ui5-lib-diff.marianzeis.de/?versionFrom=1.108.0&versionTo=1.130.0&ui5Type=SAPUI5"
+    );
+  });
+
+  it("uses one cached local bundle for both SAPUI5 and OpenUI5", async () => {
+    const fixturePath = path.join(__dirname, "fixtures", "ui5-lib-diff-sample.json");
+    const fixture = fs.readFileSync(fixturePath, "utf-8");
+    const bundlePath = writeBundleFixture(fixture);
+    CONFIG.UI5_LIB_DIFF_BUNDLE_PATH = bundlePath;
+
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as any;
+
+    await getUi5VersionDiff({
+      library: "SAPUI5",
+      from_version: "1.108.0",
+      to_version: "1.130.0",
+      limit: 1,
+    });
+    fs.unlinkSync(bundlePath);
+
+    const result = await getUi5VersionDiff({
+      library: "OpenUI5",
+      from_version: "1.108.0",
+      to_version: "1.130.0",
+      limit: 1,
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result.library).toBe("OpenUI5");
+    expect(result.meta.sourceDataPath).toBe(bundlePath);
+    expect(result.meta.cacheSource).toBe("disk");
+  });
+
+  it("fails clearly when the local bundle is missing", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ui5-lib-diff-missing-"));
+    CONFIG.UI5_LIB_DIFF_BUNDLE_PATH = path.join(tmpDir, "all-changes.json");
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as any;
+
+    await expect(
+      getUi5VersionDiff({
+        library: "SAPUI5",
+        from_version: "1.108.0",
+        to_version: "1.130.0",
+      })
+    ).rejects.toThrow(/local bundle unavailable/);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/test/ui5-version-diff.test.ts
+++ b/test/ui5-version-diff.test.ts
@@ -12,6 +12,7 @@ import {
   compareUi5Versions,
   parseUi5Version,
   normalizeChangeType,
+  getUi5VersionDiff,
 } from "../dist/src/lib/ui5LibDiff/ui5VersionDiff.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -172,5 +173,80 @@ describe("filterUi5Diff", () => {
     });
     const libs = result.entries.map((e) => e.library);
     expect(libs).toContain("deprecated");
+  });
+
+  it("clamps limit to the [1, 1000] range", () => {
+    const high = filterUi5Diff(fixture, {
+      from_version: "1.108.0",
+      to_version: "1.140.0",
+      limit: 99999,
+    });
+    expect(high.entries.length).toBeLessThanOrEqual(1000);
+    expect(high.truncated).toBe(false); // dataset is small; limit doesn't bite
+
+    const low = filterUi5Diff(fixture, {
+      from_version: "1.108.0",
+      to_version: "1.140.0",
+      limit: -5 as any,
+    });
+    expect(low.entries.length).toBeLessThanOrEqual(1);
+  });
+
+  it("coerces a malformed types argument and records a note", () => {
+    const result = filterUi5Diff(fixture, {
+      from_version: "1.108.0",
+      to_version: "1.140.0",
+      // Bad client: sends a string instead of an array.
+      types: "FEATURE" as any,
+    });
+    // Defensive coercion falls back to all three types, doesn't crash, doesn't
+    // accidentally match nothing (which is what `new Set("FEATURE")` would do).
+    expect(result.totalEntries).toBe(7);
+  });
+
+  it("emits notes when to_version exceeds dataset bounds", () => {
+    const result = filterUi5Diff(fixture, {
+      from_version: "1.108.0",
+      to_version: "1.200.0", // beyond fixture's 1.140.0
+    });
+    expect(result.meta.notes ?? []).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("newer than the newest version in the dataset"),
+      ])
+    );
+  });
+
+  it("emits notes when the range matched zero versions", () => {
+    const result = filterUi5Diff(fixture, {
+      from_version: "1.140.0",
+      to_version: "1.141.0", // no entries in this gap
+    });
+    expect(result.versionsInRange).toEqual([]);
+    expect(result.meta.notes ?? []).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("No versions matched"),
+      ])
+    );
+  });
+});
+
+describe("getUi5VersionDiff input validation", () => {
+  it("rejects from_version === to_version (degenerate range)", async () => {
+    await expect(
+      getUi5VersionDiff({ from_version: "1.130.0", to_version: "1.130.0" })
+    ).rejects.toThrow(/strictly less than/);
+  });
+
+  it("rejects from_version > to_version", async () => {
+    await expect(
+      getUi5VersionDiff({ from_version: "1.140.0", to_version: "1.108.0" })
+    ).rejects.toThrow(/strictly less than/);
+  });
+
+  it("rejects missing parameters", async () => {
+    await expect(
+      // @ts-expect-error intentionally missing required field
+      getUi5VersionDiff({ to_version: "1.130.0" })
+    ).rejects.toThrow(/requires from_version/);
   });
 });

--- a/test/ui5-version-diff.test.ts
+++ b/test/ui5-version-diff.test.ts
@@ -34,11 +34,20 @@ function writeBundleFixture(fixtureText: string): string {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ui5-lib-diff-"));
   const bundlePath = path.join(tmpDir, "all-changes.json");
   const fixture = JSON.parse(fixtureText);
+  writeBundle(bundlePath, fixture);
+  return bundlePath;
+}
+
+function writeBundle(
+  bundlePath: string,
+  fixture: any[],
+  generatedAt = "2026-05-20T00:00:00.000Z"
+): void {
   fs.writeFileSync(
     bundlePath,
     JSON.stringify({
       schemaVersion: 1,
-      generatedAt: "2026-05-20T00:00:00.000Z",
+      generatedAt,
       datasets: {
         SAPUI5: fixture,
         OpenUI5: fixture,
@@ -67,7 +76,6 @@ function writeBundleFixture(fixtureText: string): string {
     }),
     "utf-8"
   );
-  return bundlePath;
 }
 
 describe("compareUi5Versions", () => {
@@ -196,15 +204,14 @@ describe("filterUi5Diff", () => {
     expect(result.versionsInRange.length).toBe(0);
   });
 
-  it("respects limit but keeps full counts", () => {
+  it("returns all matching entries without applying a tool-level limit", () => {
     const result = filterUi5Diff(fixture, {
       from_version: "1.108.0",
       to_version: "1.140.0",
-      limit: 2,
     });
-    expect(result.entries.length).toBe(2);
+    expect(result.entries.length).toBe(7);
     expect(result.totalEntries).toBe(7);
-    expect(result.truncated).toBe(true);
+    expect("truncated" in result).toBe(false);
   });
 
   it("populates meta with dataset bounds regardless of range", () => {
@@ -227,23 +234,6 @@ describe("filterUi5Diff", () => {
     expect(libs).toContain("deprecated");
   });
 
-  it("clamps limit to the [1, 1000] range", () => {
-    const high = filterUi5Diff(fixture, {
-      from_version: "1.108.0",
-      to_version: "1.140.0",
-      limit: 99999,
-    });
-    expect(high.entries.length).toBeLessThanOrEqual(1000);
-    expect(high.truncated).toBe(false); // dataset is small; limit doesn't bite
-
-    const low = filterUi5Diff(fixture, {
-      from_version: "1.108.0",
-      to_version: "1.140.0",
-      limit: -5 as any,
-    });
-    expect(low.entries.length).toBeLessThanOrEqual(1);
-  });
-
   it("coerces a malformed types argument and records a note", () => {
     const result = filterUi5Diff(fixture, {
       from_version: "1.108.0",
@@ -263,7 +253,8 @@ describe("filterUi5Diff", () => {
     });
     expect(result.meta.notes ?? []).toEqual(
       expect.arrayContaining([
-        expect.stringContaining("newer than the newest version in the dataset"),
+        expect.stringContaining("newer than the newest version in the local bundle"),
+        expect.stringContaining("will not fetch newer data"),
       ])
     );
   });
@@ -400,12 +391,12 @@ describe("getUi5VersionDiff input validation", () => {
       library: "SAPUI5",
       from_version: "1.108.0",
       to_version: "1.130.0",
-      limit: 1,
     });
 
     expect(fetchMock).not.toHaveBeenCalled();
     expect(result.meta.sourceDataPath).toBe(bundlePath);
     expect(result.meta.cacheSource).toBe("disk");
+    expect(result.meta.generatedAt).toBe("2026-05-20T00:00:00.000Z");
     expect(result.whatsNewEntries?.length).toBe(1);
     expect(result.sourceUrl).toBe(
       "https://ui5-lib-diff.marianzeis.de/?versionFrom=1.108.0&versionTo=1.130.0&ui5Type=SAPUI5"
@@ -425,7 +416,6 @@ describe("getUi5VersionDiff input validation", () => {
       library: "SAPUI5",
       from_version: "1.108.0",
       to_version: "1.130.0",
-      limit: 1,
     });
     fs.unlinkSync(bundlePath);
 
@@ -433,13 +423,34 @@ describe("getUi5VersionDiff input validation", () => {
       library: "OpenUI5",
       from_version: "1.108.0",
       to_version: "1.130.0",
-      limit: 1,
     });
 
     expect(fetchMock).not.toHaveBeenCalled();
     expect(result.library).toBe("OpenUI5");
     expect(result.meta.sourceDataPath).toBe(bundlePath);
     expect(result.meta.cacheSource).toBe("disk");
+    expect(result.meta.generatedAt).toBe("2026-05-20T00:00:00.000Z");
+  });
+
+  it("refreshes from the local file when the in-memory bundle is missing a requested version", async () => {
+    const fixturePath = path.join(__dirname, "fixtures", "ui5-lib-diff-sample.json");
+    const fixture = JSON.parse(fs.readFileSync(fixturePath, "utf-8"));
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ui5-lib-diff-refresh-"));
+    const bundlePath = path.join(tmpDir, "all-changes.json");
+    CONFIG.UI5_LIB_DIFF_BUNDLE_PATH = bundlePath;
+
+    writeBundle(bundlePath, fixture.slice(0, 3), "2026-05-19T00:00:00.000Z");
+    await getUi5VersionDiff({ version: "1.130.0" });
+
+    writeBundle(bundlePath, fixture, "2026-05-20T00:00:00.000Z");
+    const result = await getUi5VersionDiff({ version: "1.140.0" });
+
+    expect(result.version).toBe("1.140.0");
+    expect(result.totalEntries).toBe(1);
+    expect(result.entries).toEqual([
+      expect.objectContaining({ version: "1.140.0", text: "sap.m.Button: badge support" }),
+    ]);
+    expect(result.meta.generatedAt).toBe("2026-05-20T00:00:00.000Z");
   });
 
   it("fails clearly when the local bundle is missing", async () => {

--- a/test/ui5-version-diff.test.ts
+++ b/test/ui5-version-diff.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Tests for the ui5_version_diff filter logic.
+ * Pure unit tests against a fixture file — no network calls.
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  filterUi5Diff,
+  compareUi5Versions,
+  parseUi5Version,
+  normalizeChangeType,
+} from "../dist/src/lib/ui5LibDiff/ui5VersionDiff.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+describe("compareUi5Versions", () => {
+  it("orders versions numerically, not lexicographically", () => {
+    expect(compareUi5Versions("1.100.0", "1.99.0")).toBeGreaterThan(0);
+    expect(compareUi5Versions("1.108.0", "1.108.0")).toBe(0);
+    expect(compareUi5Versions("1.108.0", "1.108.1")).toBeLessThan(0);
+    expect(compareUi5Versions("1.140.0", "1.99.0")).toBeGreaterThan(0);
+  });
+
+  it("tolerates short versions and v-prefix", () => {
+    expect(compareUi5Versions("1.120", "1.120.0")).toBe(0);
+    expect(compareUi5Versions("v1.130.0", "1.130.0")).toBe(0);
+  });
+});
+
+describe("parseUi5Version", () => {
+  it("parses three-segment versions", () => {
+    expect(parseUi5Version("1.108.0")).toEqual([1, 108, 0]);
+    expect(parseUi5Version("1.142.11")).toEqual([1, 142, 11]);
+  });
+
+  it("defaults missing segments to zero", () => {
+    expect(parseUi5Version("1.120")).toEqual([1, 120, 0]);
+    expect(parseUi5Version("1")).toEqual([1, 0, 0]);
+  });
+});
+
+describe("normalizeChangeType", () => {
+  it("normalizes the three public categories regardless of casing", () => {
+    expect(normalizeChangeType("FEATURE")).toBe("FEATURE");
+    expect(normalizeChangeType("Feature")).toBe("FEATURE");
+    expect(normalizeChangeType("feature")).toBe("FEATURE");
+    expect(normalizeChangeType("Fix")).toBe("FIX");
+    expect(normalizeChangeType("DEPRECATED")).toBe("DEPRECATED");
+  });
+
+  it("drops internal/legacy markers", () => {
+    expect(normalizeChangeType("INTERNAL")).toBeNull();
+    expect(normalizeChangeType("INETRNAL")).toBeNull();
+    expect(normalizeChangeType("LEGACY")).toBeNull();
+    expect(normalizeChangeType("[INTERNAL] ALP")).toBeNull();
+  });
+});
+
+describe("filterUi5Diff", () => {
+  let fixture: any[];
+
+  beforeAll(() => {
+    const fixturePath = path.join(__dirname, "fixtures", "ui5-lib-diff-sample.json");
+    fixture = JSON.parse(fs.readFileSync(fixturePath, "utf-8"));
+  });
+
+  it("includes changes after from_version and up to to_version (inclusive)", () => {
+    const result = filterUi5Diff(fixture, {
+      from_version: "1.108.0",
+      to_version: "1.130.0",
+    });
+
+    // 1.108.0 is excluded (the version you're leaving), 1.140.0 is outside the range.
+    // 1.120: sap.m FEATURE+FIX (2) + sap.ui.core DEPRECATED (1) = 3
+    // 1.130: sap.m FEATURE+DEPRECATED (2) + deprecated-lib DEPRECATED (1) = 3 (LEGACY dropped)
+    expect(result.versionsInRange).toEqual(["1.130.0", "1.120.0"]);
+    expect(result.totalEntries).toBe(6);
+  });
+
+  it("counts FEATURE / FIX / DEPRECATED across the range, dropping internal noise", () => {
+    const result = filterUi5Diff(fixture, {
+      from_version: "1.108.0",
+      to_version: "1.140.0",
+    });
+    // 1.120: FEATURE(1) + FIX(1) + DEPRECATED(1) = 3
+    // 1.130: FEATURE(1) + DEPRECATED(2) = 3 (LEGACY dropped)
+    // 1.140: FEATURE(1)
+    expect(result.counts).toEqual({ FEATURE: 3, FIX: 1, DEPRECATED: 3 });
+    expect(result.totalEntries).toBe(7);
+  });
+
+  it("filters by type", () => {
+    const result = filterUi5Diff(fixture, {
+      from_version: "1.108.0",
+      to_version: "1.140.0",
+      types: ["DEPRECATED"],
+    });
+    expect(result.entries.every((e) => e.type === "DEPRECATED")).toBe(true);
+    expect(result.counts.DEPRECATED).toBe(3);
+    expect(result.counts.FEATURE).toBe(0);
+    expect(result.counts.FIX).toBe(0);
+  });
+
+  it("filters by ui5_library substring (case-insensitive)", () => {
+    const result = filterUi5Diff(fixture, {
+      from_version: "1.108.0",
+      to_version: "1.140.0",
+      ui5_library: "SAP.M",
+    });
+    expect(result.entries.every((e) => e.library === "sap.m")).toBe(true);
+    expect(result.entries.length).toBeGreaterThan(0);
+  });
+
+  it("filters by query substring (case-insensitive)", () => {
+    const result = filterUi5Diff(fixture, {
+      from_version: "1.108.0",
+      to_version: "1.140.0",
+      query: "objectstatus",
+    });
+    expect(result.entries.length).toBe(1);
+    expect(result.entries[0].text).toContain("ObjectStatus");
+  });
+
+  it("rejects empty/invalid range when from > to (called via getUi5VersionDiff)", () => {
+    // filterUi5Diff itself is pure; out-of-order ranges simply yield no matches.
+    const result = filterUi5Diff(fixture, {
+      from_version: "1.130.0",
+      to_version: "1.108.0",
+    });
+    expect(result.totalEntries).toBe(0);
+    expect(result.versionsInRange.length).toBe(0);
+  });
+
+  it("respects limit but keeps full counts", () => {
+    const result = filterUi5Diff(fixture, {
+      from_version: "1.108.0",
+      to_version: "1.140.0",
+      limit: 2,
+    });
+    expect(result.entries.length).toBe(2);
+    expect(result.totalEntries).toBe(7);
+    expect(result.truncated).toBe(true);
+  });
+
+  it("populates meta with dataset bounds regardless of range", () => {
+    const result = filterUi5Diff(fixture, {
+      from_version: "1.120.0",
+      to_version: "1.130.0",
+    });
+    expect(result.meta.availableVersions).toBe(fixture.length);
+    expect(result.meta.minVersion).toBe("1.108.0");
+    expect(result.meta.maxVersion).toBe("1.140.0");
+  });
+
+  it("includes the synthetic 'deprecated' pseudo-library entries", () => {
+    const result = filterUi5Diff(fixture, {
+      from_version: "1.120.0",
+      to_version: "1.130.0",
+      types: ["DEPRECATED"],
+    });
+    const libs = result.entries.map((e) => e.library);
+    expect(libs).toContain("deprecated");
+  });
+});

--- a/test/ui5-version-diff.test.ts
+++ b/test/ui5-version-diff.test.ts
@@ -44,12 +44,20 @@ describe("parseUi5Version", () => {
 });
 
 describe("normalizeChangeType", () => {
-  it("normalizes the three public categories regardless of casing", () => {
+  it("returns canonical input unchanged (fast path matches upstream-normalized data)", () => {
     expect(normalizeChangeType("FEATURE")).toBe("FEATURE");
+    expect(normalizeChangeType("FIX")).toBe("FIX");
+    expect(normalizeChangeType("DEPRECATED")).toBe("DEPRECATED");
+  });
+
+  it("still tolerates casing variants from stale data files (defensive fallback)", () => {
+    // Once the upstream PR (marianfoo/ui5-lib-diff parseChanges.js normalization)
+    // is deployed and a refresh cycle has run, these variants no longer appear
+    // in the data. We keep the path as a safety net for stale on-disk caches
+    // produced before the upstream landed.
     expect(normalizeChangeType("Feature")).toBe("FEATURE");
     expect(normalizeChangeType("feature")).toBe("FEATURE");
     expect(normalizeChangeType("Fix")).toBe("FIX");
-    expect(normalizeChangeType("DEPRECATED")).toBe("DEPRECATED");
   });
 
   it("drops internal/legacy markers", () => {


### PR DESCRIPTION
## Goal

Make `ui5_version_diff` local-only and useful for UI5 upgrade work: setup downloads the static ui5-lib-diff bundle once, then the MCP tool filters that local file quickly at runtime.

## Content

- Loads `dist/data/ui5-lib-diff/all-changes.json` from disk only; no runtime URL fallback.
- Downloads the bundle during setup and Docker builds.
- Supports range mode `(from_version, to_version]` and single-version mode via `version`, or by supplying only one version field.
- Resolves unavailable patch versions to the nearest lower available patch in the same major.minor line, matching the ui5-lib-diff web app behavior.
- Returns all matching diff entries and all matching SAPUI5 What's New entries; the tool no longer exposes a `limit` parameter or truncation fields.
- Always includes SAPUI5 What's New entries for the same version/range without a separate parameter.
- Keeps runtime local-only. If a requested version is missing from the in-memory bundle, the tool re-reads the local file once so setup-time refreshed data can be used without external runtime requests.
- Adds `meta.generatedAt` and explicit stale-bundle notes when the requested release is newer than the local file.
- Keeps defensive type normalization and drift warnings for stale/generated data.
- Updates the UI5 upgrade skill so LLMs combine `ui5_version_diff` with SAP `@ui5/mcp-server` project checks and narrow with filters instead of limits.

## Validation

- `npm run build:tsc`
- `npm run test:ui5-version-diff` (30 tests)
- `node --check scripts/download-ui5-lib-diff.mjs`
- Local setup downloader smoke test against generated bundle
- Real-bundle smoke test: `version="1.147.0"` returned version mode, 153/153 diff entries, and 17/17 What’s New entries; `version="1.999.0"` returned local-only stale-bundle notes with `meta.generatedAt` and no external fetch.

## Integration dependency

This PR depends on marianfoo/ui5-lib-diff#11 being merged and deployed first, because setup downloads `https://ui5-lib-diff.marianzeis.de/api/v1/all-changes.json`. Until that static bundle exists on the hosted site, the GitHub Actions setup step fails with HTTP 404. Local validation against the PR #11 branch bundle succeeds.