### PR TITLE
fix: align ui5 version diff output schema with nullable commit urls

### DIFF
--- a/src/lib/ui5LibDiff/ui5VersionDiff.ts
+++ b/src/lib/ui5LibDiff/ui5VersionDiff.ts
@@ -237,6 +237,11 @@ function stripHtml(value = ""): string {
     .trim();
 }
 
+/** Keep optional string fields out of MCP structured output when absent or null. */
+export function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
 // ---------------------------------------------------------------------------
 // Type normalization
 // ---------------------------------------------------------------------------
@@ -504,17 +509,29 @@ function filterWhatsNew(
     return true;
   });
 
-  const entries = matching.map((item) => ({
-    version: item.Version ?? "",
-    title: stripHtml(item.Title ?? ""),
-    description: stripHtml(item.Description ?? ""),
-    type: item.Type,
-    action: item.Action,
-    category: item.Category,
-    validAsOf: item.Valid_as_Of,
-    url: whatsNewUrl(item),
-    id: item.id,
-  }));
+  const entries = matching.map((item) => {
+    const entry: Ui5WhatsNewEntry = {
+      version: item.Version ?? "",
+      title: stripHtml(item.Title ?? ""),
+      description: stripHtml(item.Description ?? ""),
+    };
+
+    const type = optionalString(item.Type);
+    if (type) entry.type = type;
+    const action = optionalString(item.Action);
+    if (action) entry.action = action;
+    const category = optionalString(item.Category);
+    if (category) entry.category = category;
+    const validAsOf = optionalString(item.Valid_as_Of);
+    if (validAsOf) entry.validAsOf = validAsOf;
+    const url = whatsNewUrl(item);
+    if (url) entry.url = url;
+    if (item.id !== undefined && item.id !== null) {
+      entry.id = item.id;
+    }
+
+    return entry;
+  });
 
   return {
     entries,
@@ -637,14 +654,17 @@ export function filterUi5Diff(
 
         counts[type]++;
 
-        entries.push({
+        const entry: Ui5ChangeEntry = {
           version,
-          date: block.date,
           library: libName,
           type,
           text,
-          commit_url: change.commit_url,
-        });
+        };
+        const date = optionalString(block.date);
+        if (date) entry.date = date;
+        const commitUrl = optionalString(change.commit_url);
+        if (commitUrl) entry.commit_url = commitUrl;
+        entries.push(entry);
       }
     }
   }

--- a/test/fixtures/ui5-lib-diff-sample.json
+++ b/test/fixtures/ui5-lib-diff-sample.json
@@ -96,6 +96,11 @@
           {
             "type": "FEATURE",
             "text": "sap.m.Button: badge support"
+          },
+          {
+            "type": "FIX",
+            "text": "sap.fe.controls: AI notice at column level",
+            "commit_url": null
           }
         ]
       }

--- a/test/ui5-version-diff.test.ts
+++ b/test/ui5-version-diff.test.ts
@@ -14,8 +14,10 @@ import {
   compareUi5Versions,
   parseUi5Version,
   normalizeChangeType,
+  optionalString,
   getUi5VersionDiff,
   clearUi5LibDiffCachesForTests,
+  type Ui5VersionDiffResult,
 } from "../dist/src/lib/ui5LibDiff/ui5VersionDiff.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -29,14 +31,6 @@ afterEach(() => {
   CONFIG.UI5_LIB_DIFF_BUNDLE_PATH = originalBundlePath;
   clearUi5LibDiffCachesForTests();
 });
-
-function writeBundleFixture(fixtureText: string): string {
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ui5-lib-diff-"));
-  const bundlePath = path.join(tmpDir, "all-changes.json");
-  const fixture = JSON.parse(fixtureText);
-  writeBundle(bundlePath, fixture);
-  return bundlePath;
-}
 
 function writeBundle(
   bundlePath: string,
@@ -77,6 +71,40 @@ function writeBundle(
     "utf-8"
   );
 }
+
+function writeBundleFixture(fixtureText: string): string {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ui5-lib-diff-"));
+  const bundlePath = path.join(tmpDir, "all-changes.json");
+  const fixture = JSON.parse(fixtureText);
+  writeBundle(bundlePath, fixture);
+  return bundlePath;
+}
+
+/** Mirrors ui5_version_diff outputSchema string fields that must not be null. */
+function assertNoNullOptionalStrings(result: Ui5VersionDiffResult): void {
+  for (const entry of result.entries) {
+    for (const key of ["date", "commit_url"] as const) {
+      expect(entry[key] ?? undefined).not.toBeNull();
+    }
+  }
+  for (const entry of result.whatsNewEntries) {
+    for (const key of ["type", "action", "category", "validAsOf", "url"] as const) {
+      expect(entry[key] ?? undefined).not.toBeNull();
+    }
+  }
+}
+
+describe("optionalString", () => {
+  it("returns non-empty strings and drops null, undefined, and empty values", () => {
+    expect(optionalString("https://example.com/commit")).toBe(
+      "https://example.com/commit"
+    );
+    expect(optionalString(null)).toBeUndefined();
+    expect(optionalString(undefined)).toBeUndefined();
+    expect(optionalString("")).toBeUndefined();
+    expect(optionalString(123)).toBeUndefined();
+  });
+});
 
 describe("compareUi5Versions", () => {
   it("orders versions numerically, not lexicographically", () => {
@@ -157,9 +185,9 @@ describe("filterUi5Diff", () => {
     });
     // 1.120: FEATURE(1) + FIX(1) + DEPRECATED(1) = 3
     // 1.130: FEATURE(1) + DEPRECATED(2) = 3 (LEGACY dropped)
-    // 1.140: FEATURE(1)
-    expect(result.counts).toEqual({ FEATURE: 3, FIX: 1, DEPRECATED: 3 });
-    expect(result.totalEntries).toBe(7);
+    // 1.140: FEATURE(1) + FIX(1)
+    expect(result.counts).toEqual({ FEATURE: 3, FIX: 2, DEPRECATED: 3 });
+    expect(result.totalEntries).toBe(8);
   });
 
   it("filters by type", () => {
@@ -209,8 +237,8 @@ describe("filterUi5Diff", () => {
       from_version: "1.108.0",
       to_version: "1.140.0",
     });
-    expect(result.entries.length).toBe(7);
-    expect(result.totalEntries).toBe(7);
+    expect(result.entries.length).toBe(8);
+    expect(result.totalEntries).toBe(8);
     expect("truncated" in result).toBe(false);
   });
 
@@ -243,7 +271,56 @@ describe("filterUi5Diff", () => {
     });
     // Defensive coercion falls back to all three types, doesn't crash, doesn't
     // accidentally match nothing (which is what `new Set("FEATURE")` would do).
-    expect(result.totalEntries).toBe(7);
+    expect(result.totalEntries).toBe(8);
+  });
+
+  it("omits commit_url when the bundle stores null", () => {
+    const result = filterUi5Diff(fixture, {
+      version: "1.140.0",
+      types: ["FIX"],
+    });
+
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0]).toEqual({
+      version: "1.140.0",
+      date: "2025.04.10",
+      library: "sap.m",
+      type: "FIX",
+      text: "sap.fe.controls: AI notice at column level",
+    });
+    expect(result.entries[0]).not.toHaveProperty("commit_url");
+    assertNoNullOptionalStrings(result);
+  });
+
+  it("omits optional What's New string fields when absent", () => {
+    const result = filterUi5Diff(
+      fixture,
+      { version: "1.140.0" },
+      [
+        {
+          id: 2,
+          Version: "1.140",
+          Title: "sap.m.Button",
+          Description: "Badge support.",
+          Type: null,
+          Action: null,
+          Category: "Control",
+          Valid_as_Of: null,
+          outputloio: null,
+        },
+      ]
+    );
+
+    expect(result.whatsNewEntries).toEqual([
+      {
+        version: "1.140",
+        title: "sap.m.Button",
+        description: "Badge support.",
+        category: "Control",
+        id: 2,
+      },
+    ]);
+    assertNoNullOptionalStrings(result);
   });
 
   it("emits notes when to_version exceeds dataset bounds", () => {
@@ -334,8 +411,12 @@ describe("filterUi5Diff", () => {
         version: "1.130",
         title: "sap.m.ObjectStatus",
         description: "ObjectStatus now supports emptyIndicatorMode.",
+        type: "Changed",
+        category: "Control",
       }),
     ]);
+    expect(result.whatsNewEntries[0]).not.toHaveProperty("action");
+    expect(result.whatsNewEntries[0]).not.toHaveProperty("url");
   });
 });
 
@@ -446,11 +527,44 @@ describe("getUi5VersionDiff input validation", () => {
     const result = await getUi5VersionDiff({ version: "1.140.0" });
 
     expect(result.version).toBe("1.140.0");
-    expect(result.totalEntries).toBe(1);
-    expect(result.entries).toEqual([
-      expect.objectContaining({ version: "1.140.0", text: "sap.m.Button: badge support" }),
-    ]);
+    expect(result.totalEntries).toBe(2);
+    expect(result.entries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ version: "1.140.0", text: "sap.m.Button: badge support" }),
+        expect.objectContaining({
+          version: "1.140.0",
+          text: "sap.fe.controls: AI notice at column level",
+        }),
+      ])
+    );
     expect(result.meta.generatedAt).toBe("2026-05-20T00:00:00.000Z");
+  });
+
+  it("returns MCP-safe output for a real bundle version with null commit_url values", async () => {
+    const bundlePath = path.join(
+      __dirname,
+      "..",
+      "dist",
+      "data",
+      "ui5-lib-diff",
+      "all-changes.json"
+    );
+    if (!fs.existsSync(bundlePath)) {
+      return;
+    }
+
+    CONFIG.UI5_LIB_DIFF_BUNDLE_PATH = bundlePath;
+    const result = await getUi5VersionDiff({
+      library: "SAPUI5",
+      version: "1.147.0",
+    });
+
+    expect(result.totalEntries).toBeGreaterThan(0);
+    expect(result.whatsNewTotalEntries).toBeGreaterThanOrEqual(0);
+    assertNoNullOptionalStrings(result);
+    expect(
+      result.entries.some((entry) => !("commit_url" in entry))
+    ).toBe(true);
   });
 
   it("fails clearly when the local bundle is missing", async () => {


### PR DESCRIPTION
## Summary
- Fixes Cursor/MCP structured output validation failures for `ui5_version_diff` when the local UI5 lib diff bundle contains `commit_url: null`.
- Omits optional string fields (`commit_url`, `date`, and What's New `type`/`action`/`category`/`validAsOf`/`url`) when the source value is null or empty, instead of passing null through to `structuredContent`.
- Adds regression tests, including a fixture with `commit_url: null` and a real-bundle check for SAPUI5 `1.147.0`.

## Root cause
The MCP `outputSchema` declares optional string fields like `commit_url` as `{ type: "string" }`. The local bundle stores many changes with explicit `commit_url: null` (66/153 entries for `1.147.0`), and the tool forwarded those nulls unchanged. Cursor validates `structuredContent` against the schema and rejects null for string-typed fields.

## Test plan
- [x] `npm run build:tsc`
- [x] `npm run test:ui5-version-diff`
- [x] Verified live reproduction data: SAPUI5 `1.147.0` now returns 87 entries with `commit_url` and 66 without, with zero `commit_url: null`


Made with [Cursor](https://cursor.com)