### PR TITLE
fix(ui5): drop top-level anyOf from ui5_version_diff input_schema

### DIFF
--- a/src/lib/BaseServerHandler.ts
+++ b/src/lib/BaseServerHandler.ts
@@ -723,13 +723,7 @@ ui5_version_diff(from_version="1.96.0", to_version="1.120.0", query="ObjectStatu
                   type: "string",
                   description: "Case-insensitive substring filter on change text and What's New title/description."
                 }
-              },
-              anyOf: [
-                { required: ["version"] },
-                { required: ["from_version", "to_version"] },
-                { required: ["from_version"] },
-                { required: ["to_version"] }
-              ]
+              }
             },
             outputSchema: {
               type: "object",


### PR DESCRIPTION
## Problem

The Anthropic API rejects tool schemas with `anyOf`/`oneOf`/`allOf` at the root of `input_schema`:

> `tools.N.custom.input_schema: input_schema does not support oneOf, allOf, or anyOf at the top level`

This fails **every** request that receives the tool list — not just calls to `ui5_version_diff`.

**Steps to reproduce:** Add this MCP server as a connector in Claude Desktop, then open the Claude add-in in PowerPoint or Excel. All messages fail with the API error above.

## Root cause

Introduced in b2f05d8 when single-version mode was added. `anyOf` was used to express that at least one of `version`/`from_version`/`to_version` must be present. The restriction on top-level `anyOf` is not documented in Anthropic's tool-use docs — only discoverable from the error itself.

## Fix

Removed the 6-line `anyOf` block from `BaseServerHandler.ts`. The same constraint is already enforced by runtime guards in the handler and in `ui5VersionDiff.ts`, so no replacement is needed.