### PR TITLE
feat(sap-help): weak-LLM fetch-output polish (stacked on #53)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,8 @@
         "express": "^4.21.2",
         "fast-glob": "^3.3.2",
         "gray-matter": "^4.0.3",
+        "turndown": "^7.2.4",
+        "turndown-plugin-gfm": "^1.0.2",
         "zod": "^3.23.8"
       },
       "bin": {
@@ -26,6 +28,7 @@
         "@types/cors": "^2.8.19",
         "@types/express": "^4.17.23",
         "@types/node": "^20.11.19",
+        "@types/turndown": "^5.0.6",
         "ts-node": "^10.9.2",
         "typescript": "^5.4.4",
         "vitest": "^2.1.5"
@@ -971,6 +974,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@mixmark-io/domino": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
+      "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.26.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
@@ -1813,6 +1822,13 @@
         "@types/node": "*",
         "@types/send": "*"
       }
+    },
+    "node_modules/@types/turndown": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/turndown/-/turndown-5.0.6.tgz",
+      "integrity": "sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@vitest/expect": {
       "version": "2.1.9",
@@ -4463,6 +4479,25 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/turndown": {
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.4.tgz",
+      "integrity": "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@mixmark-io/domino": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=9"
+      }
+    },
+    "node_modules/turndown-plugin-gfm": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/turndown-plugin-gfm/-/turndown-plugin-gfm-1.0.2.tgz",
+      "integrity": "sha512-vwz9tfvF7XN/jE0dGoBei3FXWuvll78ohzCZQuOb+ZjWrs3a0XhQVomJEb2Qh4VHTPNRO4GPZh0V7VRbiWwkRg==",
+      "license": "MIT"
     },
     "node_modules/type-fest": {
       "version": "0.13.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,9 @@
     "test:ui5-version-diff": "npm run build:tsc && npx vitest run test/ui5-version-diff.test.ts",
     "eval": "npm run build:tsc && node test/eval/run-eval.js",
     "eval:update": "npm run build:tsc && node test/eval/run-eval.js --update",
-    "test:version-filter": "npm run build:tsc && npx vitest run test/version-filter-sap-help.test.ts"
+    "test:version-filter": "npm run build:tsc && npx vitest run test/version-filter-sap-help.test.ts",
+    "test:citations": "npm run build:tsc && npx vitest run test/citations-sap-help.test.ts",
+    "test:html-to-md": "npm run build:tsc && npx vitest run test/html-to-md.test.ts"
   },
   "ts-node": {
     "esm": true
@@ -50,6 +52,8 @@
     "express": "^4.21.2",
     "fast-glob": "^3.3.2",
     "gray-matter": "^4.0.3",
+    "turndown": "^7.2.4",
+    "turndown-plugin-gfm": "^1.0.2",
     "zod": "^3.23.8"
   },
   "devDependencies": {
@@ -57,6 +61,7 @@
     "@types/cors": "^2.8.19",
     "@types/express": "^4.17.23",
     "@types/node": "^20.11.19",
+    "@types/turndown": "^5.0.6",
     "ts-node": "^10.9.2",
     "typescript": "^5.4.4",
     "vitest": "^2.1.5"

--- a/scripts/compare-community.mjs
+++ b/scripts/compare-community.mjs
@@ -1,0 +1,54 @@
+// Render an SAP Community post body (Khoros LiQL `body` HTML) with htmlToMarkdown vs the
+// current behaviour (raw HTML inserted verbatim — see communityBestMatch.ts getCommunityPostsByIds).
+//
+// Usage (build first):
+//   npm run build:tsc
+//   node scripts/compare-community.mjs "https://community.sap.com/t5/.../ba-p/14410686"
+//   node scripts/compare-community.mjs 14410686
+import { writeFileSync, mkdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { htmlToMarkdown } from "../dist/src/lib/htmlToMarkdown.js";
+
+const OUT_DIR = resolve("tmp/html-to-md");
+
+function extractId(arg) {
+  const m = String(arg).match(/(\d{5,})/g); // ba-p/<id> — take the last long number
+  return m ? m[m.length - 1] : arg;
+}
+
+async function main() {
+  const arg = process.argv[2] || "";
+  const id = extractId(arg);
+  const liql = `select body, subject, view_href from messages where id = '${id}'`.replace(/\s+/g, " ");
+  const url = `https://community.sap.com/api/2.0/search?q=${encodeURIComponent(liql)}`;
+
+  const res = await fetch(url, { headers: { Accept: "application/json", "User-Agent": "mcp-sap-docs/compare-community" } });
+  if (!res.ok) throw new Error(`LiQL failed: ${res.status} ${res.statusText}`);
+  const data = await res.json();
+  const post = data?.data?.items?.[0];
+  if (!post) throw new Error(`No post for id ${id} (status=${data?.status})`);
+
+  const bodyHtml = post.body || "";
+  console.log(`Post: ${post.subject}\n  id=${id}  url=${post.view_href}`);
+
+  const turndownMd = htmlToMarkdown(bodyHtml);
+
+  mkdirSync(OUT_DIR, { recursive: true });
+  const stem = `community-${id}`;
+  writeFileSync(resolve(OUT_DIR, `${stem}.html`), bodyHtml);
+  writeFileSync(resolve(OUT_DIR, `${stem}.turndown.md`), turndownMd);
+
+  const htmlTags = (bodyHtml.match(/<[a-z][^>]*>/gi) || []).length;
+  const mdTags = (turndownMd.match(/<[a-z][^>]*>/gi) || []).length;
+  console.log("\n=== Comparison ===");
+  console.table({
+    "raw HTML chars": { value: bodyHtml.length },
+    "raw HTML tags (current fetch dumps these)": { value: htmlTags },
+    "Turndown chars": { value: turndownMd.length },
+    "residual tags in Turndown MD": { value: mdTags },
+    "fenced code blocks": { value: (turndownMd.match(/```/g) || []).length / 2 },
+  });
+  console.log(`\nArtifacts:\n  ${resolve(OUT_DIR, `${stem}.html`)}\n  ${resolve(OUT_DIR, `${stem}.turndown.md`)}`);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/compare-html-to-md.mjs
+++ b/scripts/compare-html-to-md.mjs
@@ -1,0 +1,158 @@
+// A/B harness: render a real SAP Help page body with Turndown vs the legacy regex
+// converter, on identical HTML, so we can judge whether Turndown produces better Markdown.
+//
+// Usage (build first so dist/ has the converters):
+//   npm run build:tsc
+//   node scripts/compare-html-to-md.mjs "RAP behavior definition"
+//   node scripts/compare-html-to-md.mjs "managed scenario" --version 2022.002
+//
+// Writes raw HTML + both Markdown renderings to tmp/html-to-md/ and prints a summary.
+import { writeFileSync, mkdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { htmlToMarkdown, legacyHtmlToMarkdown } from "../dist/src/lib/htmlToMarkdown.js";
+
+const BASE = "https://help.sap.com";
+const OUT_DIR = resolve("tmp/html-to-md");
+
+function toQuery(params) {
+  return Object.entries(params)
+    .filter(([, v]) => v !== undefined && v !== null && v !== "")
+    .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(String(v))}`)
+    .join("&");
+}
+
+async function getJson(url, ua) {
+  const res = await fetch(url, {
+    headers: { Accept: "application/json", "User-Agent": `mcp-sap-docs/${ua}`, Referer: BASE },
+  });
+  if (!res.ok) throw new Error(`${ua} failed: ${res.status} ${res.statusText}`);
+  return res.json();
+}
+
+// Count rendered Markdown pipe-table rows ("| ... |") as a rough fidelity signal.
+function countMdTableRows(md) {
+  return (md.match(/^\s*\|.*\|\s*$/gm) || []).length;
+}
+
+// Resolve a docs page from search (query mode) or directly from a docs URL (--url mode).
+// Returns { loio, title, product_url, deliverable_url, topic_url, language, url }.
+async function resolveTarget(args, version) {
+  const urlIdx = args.indexOf("--url");
+  if (urlIdx >= 0) {
+    const pageUrl = args[urlIdx + 1];
+    const u = new URL(pageUrl, BASE);
+    const parts = u.pathname.split("/").filter(Boolean); // docs/{product}/{deliverable}/{file}.html
+    if (parts[0] !== "docs" || parts.length < 4) throw new Error(`Not a docs URL: ${pageUrl}`);
+    const loio = parts[3].replace(/\.html?$/i, "");
+    return {
+      loio,
+      title: loio,
+      product_url: parts[1],
+      deliverable_url: parts[2],
+      topic_url: parts[3],
+      language: "en-US",
+      url: u.href,
+    };
+  }
+
+  const query = args
+    .filter((a, i) => a !== "--version" && args[i - 1] !== "--version")
+    .join(" ")
+    .trim() || "RAP behavior definition";
+  console.log(`Query: "${query}"${version ? `  version=${version}` : ""}`);
+
+  const searchUrl = `${BASE}/http.svc/elasticsearch?${toQuery({
+    transtype: "standard,html,pdf,others",
+    state: "PRODUCTION,TEST,DRAFT",
+    product: "",
+    version,
+    q: query,
+    to: "19",
+    area: "content",
+    advancedSearch: "0",
+    excludeNotSearchable: "1",
+    language: "en-US",
+  })}`;
+  const search = await getJson(searchUrl, "compare-search");
+  const results = search?.data?.results || [];
+  const hit = results.find((r) => r.loio && r.loio !== "undefined" && r.loio !== "null");
+  if (!hit) throw new Error("No result with a LOIO page id for that query. Try another query.");
+  const parts = new URL(hit.url, BASE).pathname.split("/").filter(Boolean);
+  return {
+    loio: hit.loio,
+    title: hit.title,
+    product_url: hit.productId || parts[1],
+    deliverable_url: parts[2],
+    topic_url: `${hit.loio}.html`,
+    language: hit.language || "en-US",
+    url: new URL(hit.url, BASE).href,
+  };
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const versionIdx = args.indexOf("--version");
+  const version = versionIdx >= 0 ? args[versionIdx + 1] : "";
+
+  const hit = await resolveTarget(args, version);
+  console.log(`Hit: ${hit.title}\n  loio=${hit.loio}  product=${hit.product_url}  url=${hit.url}`);
+
+  // deliverableMetadata → deliverable_id / buildNo / file_path
+  const metaUrl = `${BASE}/http.svc/deliverableMetadata?${toQuery({
+    product_url: hit.product_url,
+    topic_url: hit.topic_url,
+    version: version || "LATEST",
+    loadlandingpageontopicnotfound: "true",
+    deliverable_url: hit.deliverable_url,
+    language: hit.language,
+    deliverableInfo: "1",
+    toc: "1",
+  })}`;
+  const meta = await getJson(metaUrl, "compare-metadata");
+  const deliverable_id = meta?.data?.deliverable?.id;
+  const buildNo = meta?.data?.deliverable?.buildNo;
+  const file_path = meta?.data?.filePath || `${hit.loio}.html`;
+  if (!deliverable_id || !buildNo) {
+    console.error("Metadata did not return deliverable_id/buildNo.");
+    process.exit(1);
+  }
+
+  // 3) pagecontent → raw body HTML
+  const pageUrl = `${BASE}/http.svc/pagecontent?${toQuery({ deliverableInfo: "1", deliverable_id, buildNo, file_path })}`;
+  const page = await getJson(pageUrl, "compare-content");
+  const bodyHtml = page?.data?.body || "";
+  if (!bodyHtml) {
+    console.error("pagecontent returned an empty body.");
+    process.exit(1);
+  }
+
+  // Render both ways on the identical HTML.
+  const turndownMd = htmlToMarkdown(bodyHtml);
+  const legacyMd = legacyHtmlToMarkdown(bodyHtml);
+
+  mkdirSync(OUT_DIR, { recursive: true });
+  const stem = `${hit.loio}${version ? `--v${version}` : ""}`;
+  const htmlPath = resolve(OUT_DIR, `${stem}.html`);
+  const turndownPath = resolve(OUT_DIR, `${stem}.turndown.md`);
+  const legacyPath = resolve(OUT_DIR, `${stem}.legacy.md`);
+  writeFileSync(htmlPath, bodyHtml);
+  writeFileSync(turndownPath, turndownMd);
+  writeFileSync(legacyPath, legacyMd);
+
+  const htmlTables = (bodyHtml.match(/<table[\s>]/gi) || []).length;
+  console.log("\n=== Comparison ===");
+  console.table({
+    "HTML <table> count": { value: htmlTables },
+    "raw HTML chars": { value: bodyHtml.length },
+    "Turndown chars": { value: turndownMd.length },
+    "legacy chars": { value: legacyMd.length },
+    "Turndown table rows": { value: countMdTableRows(turndownMd) },
+    "legacy table rows": { value: countMdTableRows(legacyMd) },
+  });
+  console.log(`\nArtifacts:\n  ${htmlPath}\n  ${turndownPath}\n  ${legacyPath}`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/lib/BaseServerHandler.ts
+++ b/src/lib/BaseServerHandler.ts
@@ -31,6 +31,7 @@ import {
   readDocumentationResource,
   searchCommunity
 } from "./localDocs.js";
+import { getSapHelpDocument } from "./sapHelp.js";
 import { buildLiqlSearchUrl } from "./communityBestMatch.js";
 import { lintAbapCode, LintResult } from "./abaplint.js";
 import { searchFeatureMatrix, SearchFeatureMatrixResult, getFeatureMatrixCacheStats } from "./softwareHeroes/index.js";
@@ -261,6 +262,8 @@ Unified search for ABAP + RAP development documentation. It searches across cura
 
 Use this to discover the best document IDs, then call \`fetch(id=...)\` to retrieve full content.
 
+LANGUAGE: Query in ENGLISH — the corpus and ranking are English-only; non-English queries return poor results.
+
 SOURCES OVERVIEW
 
 OFFLINE sources (local FTS index; always searched unless filtered via \`sources\`):
@@ -327,7 +330,7 @@ ESCALATION: If search returns no useful results (especially for specific error m
               properties: {
                 query: {
                   type: "string",
-                  description: "Search terms for ABAP/RAP documentation. Be specific and use technical terms."
+                  description: "Search terms for ABAP/RAP documentation, in ENGLISH (corpus is English-only). Be specific and use technical terms."
                 },
                 k: {
                   type: "number",
@@ -607,7 +610,7 @@ USE CASES:
               properties: {
                 query: {
                   type: "string",
-                  description: "Feature keywords to search for. If empty or not provided, returns all features."
+                  description: "Feature keywords to search for, in ENGLISH (matrix is English-only). If empty or not provided, returns all features."
                 },
                 limit: {
                   type: "number",
@@ -865,7 +868,7 @@ WORKFLOW:
               properties: {
                 query: {
                   type: "string",
-                  description: "Search terms for SAP Community. Be specific - use error messages, symptoms, or technical terms."
+                  description: "Search terms for SAP Community, in ENGLISH (corpus is English-only). Be specific - use error messages, symptoms, or technical terms."
                 },
                 k: {
                   type: "number",
@@ -952,7 +955,7 @@ ${contextNote}`,
               inputSchema: {
                 type: "object",
                 properties: {
-                  query: { type: "string", description: "Object name or topic keyword to search." },
+                  query: { type: "string", description: "Object name or topic keyword to search, in ENGLISH." },
                   system_type: {
                     type: "string",
                     enum: ["public_cloud", "btp", "private_cloud", "on_premise"],
@@ -1083,7 +1086,7 @@ RETURNS (JSON):
             inputSchema: {
               type: "object",
               properties: {
-                query: { type: "string", description: "Search terms for BTP services." },
+                query: { type: "string", description: "Search terms for BTP services, in ENGLISH." },
                 top: { type: "number", description: "Number of results (default 10, max 25)." },
                 category: { type: "string", description: "Category filter (e.g., 'AI', 'Integration', 'Data and Analytics')." },
                 license_model: { type: "string", enum: ["free", "payg", "subscription", "btpea", "cloudcredits"], description: "License model filter." }
@@ -1265,7 +1268,10 @@ RETURNS (JSON):
                 sourceKind: r.sourceKind || 'offline',
                 library: libraryId,
                 bm25Score: r.bm25,
-                rank: index + 1
+                rank: index + 1,
+                // SAP Help hits carry a structured citation (loio/product/version); surface it
+                // so the agent can cite/dedup/verify version without fetching. Absent otherwise.
+                ...(r.citation ?? {})
               }
             };
           });
@@ -1342,8 +1348,46 @@ RETURNS (JSON):
         const timing = logger.logToolStart(name, searchKey, clientMetadata);
         
         try {
+          // SAP Help documents carry a structured citation (loio / product / version /
+          // deliverable build) resolved during fetch — surface it as metadata instead of
+          // the generic, hardcoded `source: 'abap-docs'` path used for offline docs.
+          if (library_id.startsWith('sap-help-')) {
+            const { text, citation } = await getSapHelpDocument(library_id);
+
+            if (!text) {
+              logger.logToolSuccess(name, timing.requestId, timing.startTime, 0);
+              return createErrorResponse(`Nothing found for ${library_id}`, timing.requestId);
+            }
+
+            const document: DocumentResult = {
+              id: library_id,
+              title: citation.title || library_id,
+              text,
+              url: citation.url || `#${library_id}`,
+              metadata: {
+                source: 'sap-help',
+                sourceKind: 'sap_help',
+                loio: citation.loio ?? undefined,
+                product: citation.product,
+                requestedVersion: citation.requestedVersion,
+                version: citation.version,
+                language: citation.language,
+                deliverableId: citation.deliverableId,
+                buildNo: citation.buildNo,
+                contentLength: text.length
+              }
+            };
+
+            logger.logToolSuccess(name, timing.requestId, timing.startTime, 1, {
+              contentLength: text.length,
+              libraryId: library_id
+            });
+
+            return createDocumentResponse(document);
+          }
+
           const text = await fetchLibraryDocumentation(library_id, topic);
-          
+
           if (!text) {
             logger.logToolSuccess(name, timing.requestId, timing.startTime, 0);
             return createErrorResponse(
@@ -1351,7 +1395,7 @@ RETURNS (JSON):
               timing.requestId
             );
           }
-          
+
           // Transform document content to ChatGPT-compatible format
           const fetchedSourceUrl = extractSourceUrlFromText(text);
           const rootLibraryId = library_id.startsWith('/') ? extractLibraryIdFromPath(library_id) : library_id;

--- a/src/lib/BaseServerHandler.ts
+++ b/src/lib/BaseServerHandler.ts
@@ -1370,6 +1370,7 @@ RETURNS (JSON):
                 loio: citation.loio ?? undefined,
                 product: citation.product,
                 requestedVersion: citation.requestedVersion,
+                versionId: citation.versionId,
                 version: citation.version,
                 language: citation.language,
                 deliverableId: citation.deliverableId,

--- a/src/lib/htmlToMarkdown.ts
+++ b/src/lib/htmlToMarkdown.ts
@@ -23,6 +23,14 @@ const service = new TurndownService({
 // converter handle GFM-style HTML if other sources are routed through it later.
 service.use(gfm);
 
+// Don't backslash-escape Markdown punctuation in text. Turndown escapes `_ * . # [ ]` etc. so
+// they can't be re-parsed as Markdown, but this output is read by an LLM, not re-rendered — and
+// the escaping corrupts technical identifiers (`API_TASKPLANNINGELEMENT` → `API\_TASK…`), which
+// weaker models then copy verbatim with the stray backslash. The legacy converter never escaped;
+// matching that is more faithful. Pipe-escaping inside table cells is done explicitly in the cell
+// rule, so tables (and the headerless-table column count) are unaffected.
+service.escape = (s: string) => s;
+
 // Override the GFM cell rule: a `<td>`/`<th>` containing block elements (`<p>`, `<div>`)
 // converts to content with newlines, which breaks the single-line GFM row. Collapse any
 // internal newlines/runs of whitespace to a single space and escape literal pipes. The

--- a/src/lib/htmlToMarkdown.ts
+++ b/src/lib/htmlToMarkdown.ts
@@ -38,6 +38,57 @@ service.addRule("tableCellSingleLine", {
   },
 });
 
+// SAP's DITA pipeline (notably older NetWeaver-era ABAP reference docs) emits tables with
+// NO heading row — the first row is plain `<td>` cells inside `<tbody>`, with column labels
+// rendered via CSS, not `<th>`/`<thead>`. The gfm plugin only converts tables whose first
+// row is a heading row and otherwise `keep()`s the table as RAW HTML (a GFM pipe table is
+// invalid without a header). That left big reference tables (e.g. "ABAP System Fields", 178
+// rows) as verbose raw HTML — poor fidelity for the LLM and ~10x larger. SAP's reference
+// tables almost always use row 0 as the conceptual header, so we promote it: emit the first
+// row as the header and inject the separator the plugin omitted.
+//
+// `isHeadingRow`/`isFirstTbody` mirror the gfm plugin's internal logic verbatim so this rule
+// fires exactly on the tables the plugin would otherwise keep as raw HTML — header-bearing
+// tables fall through to the plugin's (proven) table rule untouched.
+const everyCell = Array.prototype.every;
+function isFirstTbody(element: Node): boolean {
+  const previousSibling = element.previousSibling;
+  return (
+    element.nodeName === "TBODY" &&
+    (!previousSibling ||
+      (previousSibling.nodeName === "THEAD" && /^\s*$/i.test(previousSibling.textContent ?? "")))
+  );
+}
+function isHeadingRow(tr: Node | undefined): boolean {
+  if (!tr) return false;
+  const parentNode = tr.parentNode;
+  if (!parentNode) return false;
+  return (
+    parentNode.nodeName === "THEAD" ||
+    (parentNode.firstChild === tr &&
+      (parentNode.nodeName === "TABLE" || isFirstTbody(parentNode)) &&
+      everyCell.call(tr.childNodes, (n: Node) => n.nodeName === "TH"))
+  );
+}
+service.addRule("headerlessTable", {
+  filter: (node) =>
+    node.nodeName === "TABLE" &&
+    (node as HTMLTableElement).rows.length > 0 &&
+    !isHeadingRow((node as HTMLTableElement).rows[0]),
+  replacement: (content) => {
+    // `content` is the rows already rendered as "| a | b |" lines by the cell/row rules, but
+    // with no separator (the plugin emits the separator only for heading rows). Treat row 0
+    // as the header and inject a separator sized to its column count.
+    const rows = content.split("\n").filter((l) => l.trim() !== "");
+    if (rows.length === 0) return "";
+    // Count unescaped pipes in the header row; columns = pipes - 1.
+    const cols = (rows[0].match(/(?<!\\)\|/g) || []).length - 1;
+    if (cols < 1) return `\n\n${content}\n\n`;
+    const separator = `| ${Array(cols).fill("---").join(" | ")} |`;
+    return `\n\n${[rows[0], separator, ...rows.slice(1)].join("\n")}\n\n`;
+  },
+});
+
 // Drop non-content elements outright (their text would otherwise leak into the output).
 service.remove(["script", "style", "noscript"]);
 

--- a/src/lib/htmlToMarkdown.ts
+++ b/src/lib/htmlToMarkdown.ts
@@ -1,0 +1,93 @@
+// HTML → Markdown conversion for fetched SAP Help page bodies.
+//
+// SAP Help `pagecontent` returns an HTML fragment. The previous hand-rolled regex
+// converter (kept below as `legacyHtmlToMarkdown`) dropped tables and flattened nested
+// lists — exactly the structure that matters for API/parameter reference pages. Turndown
+// handles headings, nested lists, inline/block code and links natively; the `tables` GFM
+// plugin adds pipe tables.
+import TurndownService from "turndown";
+import { gfm } from "turndown-plugin-gfm";
+
+// Configured once and reused for every fetch (the service is stateless per convert call).
+const service = new TurndownService({
+  headingStyle: "atx",          // "# Heading" — matches the rest of our markdown
+  bulletListMarker: "-",
+  codeBlockStyle: "fenced",     // ```code``` blocks
+  emDelimiter: "_",
+  hr: "---",
+});
+
+// The combined GFM plugin: pipe tables (the main thing core Turndown can't do) plus
+// strikethrough, task lists, and language-tagged `<div class="highlight-*"><pre>` code
+// blocks. Tables are what SAP Help needs today; the rest are free and let this general
+// converter handle GFM-style HTML if other sources are routed through it later.
+service.use(gfm);
+
+// Override the GFM cell rule: a `<td>`/`<th>` containing block elements (`<p>`, `<div>`)
+// converts to content with newlines, which breaks the single-line GFM row. Collapse any
+// internal newlines/runs of whitespace to a single space and escape literal pipes. The
+// prefix logic mirrors the plugin (first cell in the row opens with "| "). addRule unshifts
+// to the front of the rule list, so this takes precedence over the plugin's cell rule.
+const cellIndexOf = Array.prototype.indexOf;
+service.addRule("tableCellSingleLine", {
+  filter: ["th", "td"],
+  replacement: (content, node) => {
+    const text = content.replace(/\r?\n/g, " ").replace(/\s{2,}/g, " ").replace(/\|/g, "\\|").trim();
+    const index = node.parentNode ? cellIndexOf.call(node.parentNode.childNodes, node) : 0;
+    return (index === 0 ? "| " : " ") + text + " |";
+  },
+});
+
+// Drop non-content elements outright (their text would otherwise leak into the output).
+service.remove(["script", "style", "noscript"]);
+
+// SAP Help marks code samples as bare `<pre class="codeblock">` with no inner `<code>`,
+// so Turndown's built-in fenced-code rule (which requires `<pre><code>`) misses them.
+// Fence any `<pre>` explicitly, using the DOM's already entity-decoded textContent.
+service.addRule("preAsCodeBlock", {
+  filter: "pre",
+  replacement: (_content, node) => {
+    const text = (node.textContent ?? "").replace(/\n+$/, "");
+    return `\n\n\`\`\`\n${text}\n\`\`\`\n\n`;
+  },
+});
+
+/**
+ * The original regex-based converter, preserved verbatim. Used as the fallback when
+ * Turndown throws on malformed markup, so a conversion failure is never worse than the
+ * pre-Turndown behaviour. Also exported for side-by-side A/B comparison.
+ */
+export function legacyHtmlToMarkdown(html: string): string {
+  return html
+    .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '') // Remove scripts
+    .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '') // Remove styles
+    .replace(/<h([1-6])[^>]*>/gi, (_, level) => '\n' + '#'.repeat(parseInt(level)) + ' ') // Convert headings
+    .replace(/<\/h[1-6]>/gi, '\n') // Close headings
+    .replace(/<p[^>]*>/gi, '\n') // Paragraphs
+    .replace(/<\/p>/gi, '\n')
+    .replace(/<br[^>]*>/gi, '\n') // Line breaks
+    .replace(/<li[^>]*>/gi, '• ') // List items
+    .replace(/<\/li>/gi, '\n')
+    .replace(/<code[^>]*>/gi, '`') // Inline code
+    .replace(/<\/code>/gi, '`')
+    .replace(/<pre[^>]*>/gi, '\n```\n') // Code blocks
+    .replace(/<\/pre>/gi, '\n```\n')
+    .replace(/<[^>]+>/g, '') // Remove remaining HTML tags
+    .replace(/\s*\n\s*\n\s*/g, '\n\n') // Clean up multiple newlines
+    .replace(/^\s+|\s+$/g, '') // Trim
+    .trim();
+}
+
+/**
+ * Convert a SAP Help HTML body fragment to Markdown using Turndown (tables + nested lists
+ * preserved). Falls back to the legacy regex converter if Turndown throws, so output is
+ * never worse than the prior behaviour.
+ */
+export function htmlToMarkdown(html: string): string {
+  if (!html) return "";
+  try {
+    return service.turndown(html).trim();
+  } catch {
+    return legacyHtmlToMarkdown(html);
+  }
+}

--- a/src/lib/sapHelp.ts
+++ b/src/lib/sapHelp.ts
@@ -34,11 +34,13 @@ export interface SapHelpCitation {
    */
   requestedVersion?: string;
   /**
-   * The build actually served. On a successful pinned fetch this equals `requestedVersion`;
-   * when the pinned build is unavailable and the fetch falls back to latest (or no version was
-   * requested), it is the SAP Help API's display string for what came back (e.g. "2025 FPS01").
-   * So it also reveals what "latest" currently resolves to.
+   * The exact, pinnable SAP Help version token of the SERVED document (e.g. "2025.001", "2.0.08",
+   * "Cloud"). Pass it straight back as search's `version` to pin a follow-up to the same release —
+   * no guessing. Compare with `requestedVersion`: if they differ, the pinned build was unavailable
+   * and the fetch fell back to latest. Always present when SAP Help exposes a version.
    */
+  versionId?: string;
+  /** Human display label of the served release (e.g. "2025 FPS01 (Feb 2026)") — for showing, not filtering. */
   version?: string;
   language?: string;
   url?: string;
@@ -363,7 +365,8 @@ This SAP Help search result does not expose a LOIO page id through the search AP
       const citation: SapHelpCitation = {
         loio: null,
         product: hit.product || hit.productId,
-        version: version || hit.version || hit.versionId,
+        versionId: hit.versionId,                  // pinnable token of the served doc
+        version: hit.version || hit.versionId,     // human display label
         language: hit.language || "en-US",
         url: ensureAbsoluteUrl(hit.url),
         title: hit.title,
@@ -442,7 +445,8 @@ ${cleanText}
     const citation: SapHelpCitation = {
       loio: hit.loio,
       product: hit.product || hit.productId || product_url,
-      version: version || hit.version || hit.versionId,
+      versionId: hit.versionId,                  // pinnable token of the served doc
+      version: hit.version || hit.versionId,     // human display label
       language,
       url: ensureAbsoluteUrl(hit.url),
       title,

--- a/src/lib/sapHelp.ts
+++ b/src/lib/sapHelp.ts
@@ -8,6 +8,7 @@ import {
   SapHelpPageContentResponse
 } from "./types.js";
 import { truncateContent } from "./truncate.js";
+import { htmlToMarkdown } from "./htmlToMarkdown.js";
 
 const BASE = "https://help.sap.com";
 
@@ -16,6 +17,36 @@ const BASE = "https://help.sap.com";
 // it as the version delimiter and let the opaque versionId ride through verbatim (see encodeSapHelpId).
 const ID_PREFIX = "sap-help-";
 const VERSION_SEP = "~";
+
+/**
+ * Structured citation for a SAP Help document: the stable cross-release identity
+ * (`loio`), the resolved page title/url, and the exact deliverable build the
+ * content came from. `deliverableId`/`buildNo` are only available on the full LOIO
+ * fetch path; the no-LOIO branch leaves them (and `loio`) undefined/null.
+ */
+export interface SapHelpCitation {
+  loio?: string | null;
+  product?: string;
+  /**
+   * The version the caller asked for, parsed from the id suffix ("2025.001"); undefined when
+   * the id carried no version (i.e. latest was requested). Compare against `version` to detect
+   * whether version-pinning succeeded or the fetch fell back to latest.
+   */
+  requestedVersion?: string;
+  /**
+   * The build actually served. On a successful pinned fetch this equals `requestedVersion`;
+   * when the pinned build is unavailable and the fetch falls back to latest (or no version was
+   * requested), it is the SAP Help API's display string for what came back (e.g. "2025 FPS01").
+   * So it also reveals what "latest" currently resolves to.
+   */
+  version?: string;
+  language?: string;
+  url?: string;
+  title?: string;
+  // The SAP Help API returns these as numbers; keep them faithful rather than coercing.
+  deliverableId?: string | number;
+  buildNo?: string | number;
+}
 
 // ---------- Utils ----------
 function toQuery(params: Record<string, any>): string {
@@ -232,8 +263,20 @@ export function parseSapHelpId(resultId: string): { helpId: string; version?: st
  * First gets metadata, then page content
  */
 export async function getSapHelpContent(resultId: string): Promise<string> {
-  // fetch retrieves the same release the caller searched: search encodes the version into
-  // the id, parseSapHelpId pulls it back off. No suffix → latest (prior behaviour).
+  return (await getSapHelpDocument(resultId)).text;
+}
+
+/**
+ * Like `getSapHelpContent`, but also returns the structured citation (loio / product /
+ * version / url / title plus the resolved deliverable build). The fetch handler uses this
+ * to surface citation metadata; `getSapHelpContent` is the thin string-only wrapper kept
+ * unchanged for existing callers.
+ */
+export async function getSapHelpDocument(
+  resultId: string
+): Promise<{ text: string; citation: SapHelpCitation }> {
+  // fetch retrieves the same release the caller searched: search encodes the version into the
+  // id, parseSapHelpId pulls it back off. No suffix → latest (prior behaviour).
   const { helpId, version } = parseSapHelpId(resultId);
   if (!helpId) {
     throw new Error("Invalid SAP Help result ID. Use an ID from sap_help_search results.");
@@ -243,14 +286,17 @@ export async function getSapHelpContent(resultId: string): Promise<string> {
   // (latest) path — exactly what fetch returned before this feature, so we are never worse
   // than the prior behaviour. This is not a retry of the same request: the fallback is a
   // different, known-good request (the pre-version code path).
-  let content = await resolveSapHelpContent(helpId, version);
-  if (content === null && version) {
-    content = await resolveSapHelpContent(helpId, undefined);
+  let resolved = await resolveSapHelpContent(helpId, version);
+  if (resolved === null && version) {
+    resolved = await resolveSapHelpContent(helpId, undefined);
   }
-  if (content === null) {
+  if (resolved === null) {
     throw new Error(`Failed to get SAP Help content for ${helpId}`);
   }
-  return content;
+  // requestedVersion is known only here (the inner resolve sees `undefined` on the fallback
+  // call, so it can't record what was originally asked for). Stamp it on the citation so the
+  // caller can compare requested-vs-served and tell whether pinning held or fell back.
+  return { text: resolved.content, citation: { ...resolved.citation, requestedVersion: version } };
 }
 
 /**
@@ -261,7 +307,10 @@ export async function getSapHelpContent(resultId: string): Promise<string> {
  *   - set       → version-pinned: re-search for that release's deliverable and request the
  *                 version-matched build (older "LATEST" builds can be partial/500 on some pages)
  */
-async function resolveSapHelpContent(helpId: string, version?: string): Promise<string | null> {
+async function resolveSapHelpContent(
+  helpId: string,
+  version?: string
+): Promise<{ content: string; citation: SapHelpCitation } | null> {
   const reSearchVersion = version ?? "";        // "" = latest (prior behaviour)
   const metadataVersion = version ?? "LATEST";  // version-matched build, else latest
   try {
@@ -311,7 +360,15 @@ This SAP Help search result does not expose a LOIO page id through the search AP
 ---
 
 *This content is from the SAP Help Portal and represents official SAP documentation.*`;
-      return truncateContent(fullContent).content;
+      const citation: SapHelpCitation = {
+        loio: null,
+        product: hit.product || hit.productId,
+        version: version || hit.version || hit.versionId,
+        language: hit.language || "en-US",
+        url: ensureAbsoluteUrl(hit.url),
+        title: hit.title,
+      };
+      return { content: truncateContent(fullContent).content, citation };
     }
 
     // Prepare metadata request parameters
@@ -362,25 +419,8 @@ This SAP Help search result does not expose a LOIO page id through the search AP
     const bodyHtml = pageData?.data?.body || "";
     if (!bodyHtml) return null; // empty body → allow fallback to the default path
 
-    // Convert HTML to readable text while preserving structure
-    const cleanText = bodyHtml
-      .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '') // Remove scripts
-      .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '') // Remove styles
-      .replace(/<h([1-6])[^>]*>/gi, (_, level) => '\n' + '#'.repeat(parseInt(level)) + ' ') // Convert headings
-      .replace(/<\/h[1-6]>/gi, '\n') // Close headings
-      .replace(/<p[^>]*>/gi, '\n') // Paragraphs
-      .replace(/<\/p>/gi, '\n')
-      .replace(/<br[^>]*>/gi, '\n') // Line breaks
-      .replace(/<li[^>]*>/gi, '• ') // List items
-      .replace(/<\/li>/gi, '\n')
-      .replace(/<code[^>]*>/gi, '`') // Inline code
-      .replace(/<\/code>/gi, '`')
-      .replace(/<pre[^>]*>/gi, '\n```\n') // Code blocks
-      .replace(/<\/pre>/gi, '\n```\n')
-      .replace(/<[^>]+>/g, '') // Remove remaining HTML tags
-      .replace(/\s*\n\s*\n\s*/g, '\n\n') // Clean up multiple newlines
-      .replace(/^\s+|\s+$/g, '') // Trim
-      .trim();
+    // Convert the HTML fragment to Markdown, preserving tables, nested lists and code.
+    const cleanText = htmlToMarkdown(bodyHtml);
 
     const fullContent = `# ${title}
 
@@ -399,7 +439,17 @@ ${cleanText}
 
 *This content is from the SAP Help Portal and represents official SAP documentation.*`;
 
-    return truncateContent(fullContent).content;
+    const citation: SapHelpCitation = {
+      loio: hit.loio,
+      product: hit.product || hit.productId || product_url,
+      version: version || hit.version || hit.versionId,
+      language,
+      url: ensureAbsoluteUrl(hit.url),
+      title,
+      deliverableId: deliverable_id,
+      buildNo,
+    };
+    return { content: truncateContent(fullContent).content, citation };
   } catch {
     return null; // any error → allow fallback (caller throws if no path succeeds)
   }

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -17,6 +17,13 @@ export type SearchResult = {
   relFile: string;
   finalScore: number;
   sourceKind: 'offline' | 'sap_help' | 'sap_community' | 'software_heroes' | 'semantic';
+  // Structured citation for online (SAP Help) hits — surfaced in the MCP search result
+  // metadata so the agent can cite/dedup/verify the version without a fetch round-trip.
+  citation?: {
+    loio?: string;
+    product?: string;
+    version?: string;
+  };
   // Debug info for ranking analysis
   debug?: {
     bm25Score?: number;
@@ -271,6 +278,17 @@ function processOnlineSource(
       relFile: '',
       finalScore,
       sourceKind,
+      // SAP Help hits carry loio/product/version in their metadata (set by searchSapHelp);
+      // preserve it as a citation so the MCP layer can expose it in the result metadata.
+      ...(sourceKind === 'sap_help' && r.metadata
+        ? {
+            citation: {
+              loio: r.metadata.loio ?? undefined,
+              product: r.metadata.product,
+              version: r.metadata.version
+            }
+          }
+        : {}),
       debug: { rank, rrfScore, boost }
     };
   });

--- a/src/types/turndown-plugin-gfm.d.ts
+++ b/src/types/turndown-plugin-gfm.d.ts
@@ -1,0 +1,12 @@
+// Minimal ambient declaration: turndown-plugin-gfm ships no TypeScript types.
+// `gfm` is the combined plugin (tables + strikethrough + task lists + highlighted code);
+// the individual plugins are exported too.
+declare module "turndown-plugin-gfm" {
+  import type TurndownService from "turndown";
+  type Plugin = (service: TurndownService) => void;
+  export const gfm: Plugin;
+  export const tables: Plugin;
+  export const strikethrough: Plugin;
+  export const taskListItems: Plugin;
+  export const highlightedCodeBlock: Plugin;
+}

--- a/test/citations-sap-help.test.ts
+++ b/test/citations-sap-help.test.ts
@@ -57,9 +57,11 @@ describe("SAP Help structured citations (item 8)", () => {
       expect(citation.loio).toBe(FEATURE_LOIO);
       // requestedVersion is parsed from the id — deterministic, no network dependence.
       expect(citation.requestedVersion).toBe(VERSION);
-      // version is the SERVED build: equals requestedVersion on a successful pinned fetch, or
-      // the API display string when the pinned build 500s and the fetch falls back to latest.
-      // Either way it must be a non-empty string the agent can compare against requestedVersion.
+      // versionId is the served doc's exact, pinnable token (not the spaced display string) — a
+      // caller passes it straight back as `version` to re-pin. Present and token-shaped (no spaces).
+      expect(citation.versionId).toBeTruthy();
+      expect(citation.versionId).not.toMatch(/\s/);
+      // version is the human display label of the served release — a non-empty string for showing.
       expect(citation.version && citation.version.length).toBeGreaterThan(0);
       expect(citation.url).toMatch(/^https:\/\/help\.sap\.com\//);
       expect(citation.title && citation.title.length).toBeGreaterThan(0);

--- a/test/citations-sap-help.test.ts
+++ b/test/citations-sap-help.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Acceptance test for structured SAP Help citations (roadmap item 8).
+ *
+ * Item 1/1b made fetch version-correct; item 8 surfaces the document's identity as
+ * structured fields (loio / product / version / url / title + the resolved deliverable
+ * build) instead of burying them in the rendered content header. The agent uses these
+ * to cite precisely, dedup across versions, and verify it quoted the right build.
+ *
+ * Two contracts under test:
+ *   - fetch: getSapHelpDocument returns { text, citation }; getSapHelpContent stays a
+ *     string-only wrapper returning exactly that text (existing callers unaffected).
+ *   - search: the unified search result carries citation { loio, product, version }.
+ *
+ * This is a NETWORK test — it hits help.sap.com and skips gracefully at RUNTIME when the
+ * endpoint is unreachable, so offline CI stays green. Run with:
+ *   npm run test:citations
+ */
+
+import { describe, it, expect } from "vitest";
+import { searchSapHelp, getSapHelpContent, getSapHelpDocument } from "../src/lib/sapHelp.js";
+import { search } from "../src/lib/search.js";
+import type { SearchResponse } from "../src/lib/types.js";
+
+const QUERY = "Task Planning Element API_TASKPLANNINGELEMENT synchronous inbound OData";
+const FEATURE_LOIO = "920ead13c8c84b9fa70a06197a7d4d10";
+const VERSION = "2025.001"; // S/4HANA 2025 FPS01 — feature present
+const NET_TIMEOUT = 30_000;
+
+/** Locate the version-pinned result id for the feature, or skip if SAP Help is unreachable. */
+async function feedId(ctx: { skip: () => void }): Promise<string> {
+  let res: SearchResponse;
+  try {
+    res = await searchSapHelp(QUERY, VERSION);
+  } catch (e: any) {
+    console.warn(`[citations] SAP Help threw, skipping: ${e?.message}`);
+    ctx.skip();
+    return "";
+  }
+  if (res.error || (res.results?.length ?? 0) === 0) {
+    console.warn(`[citations] SAP Help unreachable/empty, skipping (error: ${res.error ?? "none"})`);
+    ctx.skip();
+    return "";
+  }
+  const hit = (res.results ?? []).find((r) => r.metadata?.loio === FEATURE_LOIO);
+  if (!hit) ctx.skip();
+  return hit!.id;
+}
+
+describe("SAP Help structured citations (item 8)", () => {
+  it(
+    "getSapHelpDocument returns a structured citation for a version-pinned LOIO fetch",
+    async (ctx) => {
+      const id = await feedId(ctx);
+      const { text, citation } = await getSapHelpDocument(id);
+
+      // Identity + provenance the agent cites against — always present.
+      expect(citation.loio).toBe(FEATURE_LOIO);
+      // requestedVersion is parsed from the id — deterministic, no network dependence.
+      expect(citation.requestedVersion).toBe(VERSION);
+      // version is the SERVED build: equals requestedVersion on a successful pinned fetch, or
+      // the API display string when the pinned build 500s and the fetch falls back to latest.
+      // Either way it must be a non-empty string the agent can compare against requestedVersion.
+      expect(citation.version && citation.version.length).toBeGreaterThan(0);
+      expect(citation.url).toMatch(/^https:\/\/help\.sap\.com\//);
+      expect(citation.title && citation.title.length).toBeGreaterThan(0);
+      expect(citation.title).not.toContain("sap-help-"); // resolved page title, not the raw id
+
+      // deliverableId/buildNo pin the exact build, but only the full-LOIO fetch path produces
+      // them; the no-LOIO branch and some fallbacks legitimately omit them. Assert they're
+      // well-formed WHEN present rather than requiring them (matches the optional interface).
+      // (API returns these as numbers; stringify before length-checking.)
+      if (citation.deliverableId !== undefined) expect(String(citation.deliverableId).length).toBeGreaterThan(0);
+      if (citation.buildNo !== undefined) expect(String(citation.buildNo).length).toBeGreaterThan(0);
+
+      expect(text).toMatch(/Task Planning/i);
+    },
+    NET_TIMEOUT
+  );
+
+  it(
+    "getSapHelpContent stays a string wrapper returning exactly the document text",
+    async (ctx) => {
+      const id = await feedId(ctx);
+      const [stringContent, doc] = await Promise.all([
+        getSapHelpContent(id),
+        getSapHelpDocument(id),
+      ]);
+      expect(stringContent).toBe(doc.text); // unchanged contract for existing callers
+    },
+    NET_TIMEOUT
+  );
+
+  it(
+    "unified search carries citation (loio/product/version) on SAP Help hits",
+    async (ctx) => {
+      let results;
+      try {
+        results = await search(QUERY, { includeOnline: true, version: VERSION });
+      } catch (e: any) {
+        console.warn(`[citations] unified search threw, skipping: ${e?.message}`);
+        ctx.skip();
+        return;
+      }
+      const hit = results.find((r) => r.sourceKind === "sap_help" && r.citation?.loio === FEATURE_LOIO);
+      if (!hit) {
+        console.warn("[citations] no SAP Help hit for feature (network/empty), skipping");
+        ctx.skip();
+        return;
+      }
+      expect(hit.citation?.loio).toBe(FEATURE_LOIO);
+      expect(hit.citation?.version).toBeTruthy();
+    },
+    NET_TIMEOUT
+  );
+});

--- a/test/html-to-md.test.ts
+++ b/test/html-to-md.test.ts
@@ -59,6 +59,50 @@ describe("htmlToMarkdown — conversion behaviour", () => {
     for (const row of rows) expect(row.trim().endsWith("|")).toBe(true);
   });
 
+  it("converts a headerless <td>-only table (SAP DITA pattern) to a pipe table", () => {
+    // Mirrors the real "ABAP System Fields" markup: a <colgroup>, no <thead>/<th>, and the
+    // first row is plain <td> cells inside <tbody>. The gfm plugin keeps such tables as raw
+    // HTML; our rule promotes row 0 to the header and injects the separator.
+    const html = `<table summary="" class="table" frame="border" border="1" rules="all">
+      <colgroup><col width="50%"><col width="50%"></colgroup>
+      <tbody class="tbody">
+        <tr class="row"><td class="entry"><p class="p">Name</p></td><td class="entry"><p class="p">Type</p></td></tr>
+        <tr class="row"><td class="entry"><p class="p">sy-subrc</p></td><td class="entry"><p class="p">i</p></td></tr>
+        <tr class="row"><td class="entry"><p class="p">sy-tabix</p></td><td class="entry"><p class="p">i</p></td></tr>
+      </tbody></table>`;
+    const md = htmlToMarkdown(html);
+    expect(md).toContain("| Name | Type |");
+    expect(md).toContain("| --- | --- |");
+    expect(md).toContain("| sy-subrc | i |");
+    expect(md).toContain("| sy-tabix | i |");
+    // The whole point: no raw HTML table markup leaks through.
+    expect(md).not.toMatch(/<t(able|r|d|body)[\s>]/i);
+  });
+
+  it("leaves header-bearing tables on the plugin's path (no double separator)", () => {
+    const html = `<table><thead><tr><th>Code</th><th>Name</th></tr></thead>
+      <tbody><tr><td>VA01</td><td>Create</td></tr></tbody></table>`;
+    const md = htmlToMarkdown(html);
+    expect(md).toContain("| Code | Name |");
+    expect(md).toContain("| VA01 | Create |");
+    // Exactly one separator row — our headerless rule must NOT also fire here.
+    expect((md.match(/^\s*\|(?:\s*---\s*\|)+\s*$/gm) || []).length).toBe(1);
+  });
+
+  it("handles a headerless table with an empty leading corner cell", () => {
+    // SAP reference tables often have an empty top-left corner cell; column count must still
+    // be correct so the separator matches.
+    const html = `<table><tbody>
+      <tr><td></td><td>Name</td><td>Type</td></tr>
+      <tr><td>1</td><td>sy-subrc</td><td>i</td></tr>
+    </tbody></table>`;
+    const md = htmlToMarkdown(html);
+    const sep = (md.match(/^\s*\|(?:\s*---\s*\|)+\s*$/gm) || [])[0] || "";
+    // Three columns -> three "---" groups.
+    expect((sep.match(/---/g) || []).length).toBe(3);
+    expect(md).toContain("| 1 | sy-subrc | i |");
+  });
+
   it("converts headings and inline code", () => {
     const md = htmlToMarkdown(`<h2>Overview</h2><p>Use <code>NEW</code>.</p>`);
     expect(md).toContain("## Overview");

--- a/test/html-to-md.test.ts
+++ b/test/html-to-md.test.ts
@@ -113,6 +113,16 @@ describe("htmlToMarkdown — conversion behaviour", () => {
     expect(htmlToMarkdown("")).toBe("");
   });
 
+  it("does NOT backslash-escape Markdown punctuation in identifiers (faithful for LLMs)", () => {
+    // Turndown escapes `_ * .` by default, which mangles API/field names a weak model then
+    // copies verbatim. We disable escaping; the identifier must survive byte-for-byte.
+    const md = htmlToMarkdown(`<p>Call <span>API_TASK_PLANNING</span>; rate is 3*x; see file_1.txt.</p>`);
+    expect(md).toContain("API_TASK_PLANNING");
+    expect(md).toContain("3*x");
+    expect(md).toContain("file_1.txt");
+    expect(md).not.toContain("\\");
+  });
+
   // The following pin the combined-`gfm` behaviours. They don't appear in SAP Help bodies
   // today, but this is a general converter — guard them in case other sources are added.
   it("language-tags a div.highlight code block without double-fencing", () => {

--- a/test/html-to-md.test.ts
+++ b/test/html-to-md.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { htmlToMarkdown, legacyHtmlToMarkdown } from "../src/lib/htmlToMarkdown.js";
+
+// Pure-function tests — no network.
+//
+// The first group is the *reason* we switched: each case asserts the Turndown output AND
+// the matching deficiency in the old regex converter (`legacyHtmlToMarkdown`), so the suite
+// doubles as documentation of the fidelity gain. Only genuine improvements are contrasted —
+// headings and inline `<code>` are NOT here because legacy already handled them.
+describe("htmlToMarkdown — improvements over the legacy regex converter", () => {
+  it("renders <table> as a GFM pipe table; legacy concatenated the cells", () => {
+    const html = `<table><thead><tr><th>Transaction</th><th>Description</th></tr></thead>
+      <tbody><tr><td>VA01</td><td>Create Sales Order</td></tr></tbody></table>`;
+    const md = htmlToMarkdown(html);
+    expect(md).toContain("| Transaction | Description |");
+    expect(md).toContain("| --- | --- |");
+    expect(md).toContain("| VA01 | Create Sales Order |");
+    // Legacy has no table support: it strips the tags and runs cells together ("VA01Create…").
+    const legacy = legacyHtmlToMarkdown(html);
+    expect(legacy).not.toContain("|");
+    expect(legacy).toContain("VA01Create Sales Order");
+  });
+
+  it("preserves nested list structure; legacy flattened it onto one line", () => {
+    const html = `<ul><li>Parent<ul><li>Child</li></ul></li></ul>`;
+    const md = htmlToMarkdown(html);
+    expect(md).toMatch(/-\s+Parent/);
+    expect(md).toMatch(/\n\s+-\s+Child/); // child indented under parent
+    // Legacy emits bullets with no nesting and no line breaks: "• Parent• Child".
+    expect(legacyHtmlToMarkdown(html)).toBe("• Parent• Child");
+  });
+
+  it("decodes HTML entities in code; legacy left them raw", () => {
+    const html = `<pre class="codeblock">SELECT * FROM mara WHERE matnr &lt; '100' &amp; ok</pre>`;
+    const md = htmlToMarkdown(html);
+    expect(md).toContain("```");
+    expect(md).toContain("matnr < '100' & ok"); // &lt; / &amp; decoded
+    expect(md).not.toContain("&lt;");
+    // Legacy strips tags but never decodes entities — raw "&lt;"/"&amp;" leak into the output.
+    expect(legacyHtmlToMarkdown(html)).toContain("&lt;");
+  });
+
+  it("keeps emphasis; legacy dropped it to plain text", () => {
+    const html = `<p>You should <strong>avoid</strong> MOVE.</p>`;
+    expect(htmlToMarkdown(html)).toContain("**avoid**");
+    expect(legacyHtmlToMarkdown(html)).not.toContain("**"); // legacy → "You should avoid MOVE."
+  });
+});
+
+// Correctness + edge cases (not necessarily improvements over legacy).
+describe("htmlToMarkdown — conversion behaviour", () => {
+  it("keeps a table row on one line when a cell contains block elements", () => {
+    const html = `<table><tr><th>Code</th><th>Name</th></tr>
+      <tr><td><p>VA03</p></td><td>Display Sales Order</td></tr></table>`;
+    const md = htmlToMarkdown(html);
+    expect(md).toContain("| VA03 | Display Sales Order |");
+    // No data row should start with "|" yet fail to end with "|".
+    const rows = md.split("\n").filter((l) => l.trim().startsWith("|"));
+    for (const row of rows) expect(row.trim().endsWith("|")).toBe(true);
+  });
+
+  it("converts headings and inline code", () => {
+    const md = htmlToMarkdown(`<h2>Overview</h2><p>Use <code>NEW</code>.</p>`);
+    expect(md).toContain("## Overview");
+    expect(md).toContain("`NEW`");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(htmlToMarkdown("")).toBe("");
+  });
+
+  // The following pin the combined-`gfm` behaviours. They don't appear in SAP Help bodies
+  // today, but this is a general converter — guard them in case other sources are added.
+  it("language-tags a div.highlight code block without double-fencing", () => {
+    const html = `<div class="highlight-source-js"><pre>const x = 1;</pre></div>`;
+    const md = htmlToMarkdown(html);
+    expect(md).toContain("```js");
+    expect(md).toContain("const x = 1;");
+    // Exactly one opening+closing fence pair — our bare-<pre> rule must not also fire here.
+    expect((md.match(/```/g) || []).length).toBe(2);
+  });
+
+  it("still fences a bare <pre> when there is no highlight wrapper", () => {
+    expect(htmlToMarkdown(`<pre>plain code</pre>`)).toContain("```\nplain code\n```");
+  });
+
+  it("renders strikethrough", () => {
+    expect(htmlToMarkdown(`<p><del>old</del> new</p>`)).toContain("~old~");
+  });
+});


### PR DESCRIPTION
**Stacks on #53** (SAP Help citations + Turndown + table fix). The reviewable delta is the single top commit `7964289` — the rest of this diff is #53. After #53 merges, this branch rebases onto `main` and shows only that commit.

## What this adds
Two small output-quality fixes on the SAP Help **fetch** path (search defaults are untouched), each validated by sampling real `help.sap.com` content:

1. **Disable Turndown's Markdown escaping.** It backslash-escapes `_ * .` in technical identifiers — `API_TASKPLANNINGELEMENT` → `API\_TASKPLANNINGELEMENT` — which weaker models copy verbatim with the stray backslash. The legacy converter never escaped; this matches it. Table-cell pipe-escaping is explicit, so tables (incl. the headerless-table column count from #53) are unaffected. *Verified live: 0 backslashes in output, tables still produce pipe rows.*
2. **Citation carries the pinnable `versionId` token.** The served doc's exact filter token (e.g. `2025.001`), distinct from the human display `version` (`2025 FPS01 (Feb 2026)`). A caller passes `versionId` straight back as search's `version` to re-pin the same release — no guessing; comparing it with `requestedVersion` reveals a latest-fallback. *Verified live: `versionId:"2025.001"` vs `version:"2025 FPS01 (Feb 2026)"`.*

## Deliberately NOT included
A residual-HTML strip / legacy fallback. Sampling 11 docs showed the only post-table-fix residue is **correctly-decoded placeholder text** (`https://<host>:<port>/…`) that Turndown renders *better* than legacy — stripping it would corrupt content.

## Testing
- Offline: `html-to-md` (escape + tables) and id round-trip — 29/29.
- Network: citations + version-filter — 9/9 (citation now asserts a token-shaped `versionId`).
- No new regressions (same pre-existing OpenUI5 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)