### PR TITLE
fix(ci): pass -R to gh workflow run so release dispatch works

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,5 +27,5 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh workflow run deploy-mcp-sap-docs.yml --ref main
-          gh workflow run sync-to-abap-main.yml --ref main
+          gh workflow run deploy-mcp-sap-docs.yml --ref main -R ${{ github.repository }}
+          gh workflow run sync-to-abap-main.yml --ref main -R ${{ github.repository }}


### PR DESCRIPTION
## Problem

The `Trigger deploy + ABAP sync on new release` step in `release-please.yml` failed:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

`release-please-action` does not check out the repo, so `gh workflow run` had no local `.git` to infer the target repo from.

## Fix

Pass `-R ${{ github.repository }}` explicitly on both `gh workflow run` calls. No checkout step needed.

Verifies end-to-end: merging this `fix:` commit opens a 0.3.47 release PR; merging that PR exercises the now-fixed dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)