### PR TITLE
fix(build): rebuild better-sqlite3 in setup so Node ABI upgrades don't break deploy

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,5 +27,5 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh workflow run deploy-mcp-sap-docs.yml --ref main
-          gh workflow run sync-to-abap-main.yml --ref main
+          gh workflow run deploy-mcp-sap-docs.yml --ref main -R ${{ github.repository }}
+          gh workflow run sync-to-abap-main.yml --ref main -R ${{ github.repository }}

--- a/setup.sh
+++ b/setup.sh
@@ -9,6 +9,12 @@ printf '🚀 Setting up SAP Documentation MCP Server...\n'
 printf '📦 Installing dependencies...\n'
 npm install
 
+# Rebuild the native addon against the *current* Node ABI. `npm install` keeps a
+# cached better-sqlite3 build, so a server Node upgrade (e.g. 22→24) leaves a
+# NODE_MODULE_VERSION mismatch that only surfaces at runtime in build-fts.
+# ponytail: rebuild only the one native dep; drop this if Node ever gets pinned on the server.
+npm rebuild better-sqlite3
+
 # Initialize and update git submodules
 printf '📚 Initializing documentation submodules...\n'
 


### PR DESCRIPTION
## Problem

Deploy failed in `build-fts`:

```
better_sqlite3.node was compiled against ... NODE_MODULE_VERSION 115 (Node 22).
This version of Node.js requires NODE_MODULE_VERSION 127 (Node 24).
ERR_DLOPEN_FAILED
```

The server's Node was upgraded to 24, but `setup.sh` runs `npm install`, which reuses the cached Node-22 build of `better-sqlite3` — it does not detect an ABI mismatch, so the native module is never recompiled.

## Fix

Add `npm rebuild better-sqlite3` right after `npm install` in `setup.sh`. It recompiles against whichever Node is active, so the deploy is resilient to future Node drift on the server.

After merge, re-run the **Deploy MCP stack** workflow (workflow_dispatch) to verify on the server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)