### PR TITLE
docs: explain BTP CF deployment tradeoffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,8 +265,10 @@ For BTP CF, the recommended `sap-docs` path is to deploy the maintained
 pulls and runs the prepared semantic image.
 
 See [docs/BTP-CF-DEPLOYMENT.md](docs/BTP-CF-DEPLOYMENT.md) for the public-first
-deployment guide, MTA descriptor, direct `cf push` manifest, daily refresh setup,
-and the Node.js buildpack package test result.
+deployment guide. Start with
+[Deployment Options and Tradeoffs](docs/BTP-CF-DEPLOYMENT.md#deployment-options-and-tradeoffs)
+to choose between MTA, direct `cf push`, custom registry images, and refresh
+setup.
 
 ## One-Way Sync to `abap-mcp-server`
 

--- a/docs/BTP-CF-DEPLOYMENT.md
+++ b/docs/BTP-CF-DEPLOYMENT.md
@@ -110,65 +110,51 @@ profile when the goal is search quality and the target space can fit it.
 
 ## Cost Estimate
 
-SAP BTP, Cloud Foundry Runtime is metered on reserved runtime memory, not on
-actual heap usage or request count. Load changes the cost only when you scale the
-deployment by increasing memory per instance, increasing the number of running
-instances, or running it for more hours. A stopped app does not reserve runtime
-memory.
-
-SAP documents the monthly Cloud Foundry Runtime calculation as:
+SAP BTP, Cloud Foundry Runtime is billed by reserved runtime memory, not actual
+heap usage or request count. Request load changes the bill only when it makes you
+increase memory, instances, or running hours. A stopped app does not reserve
+runtime memory.
 
 ```text
-billable GB/month =
-  ceil(sum(memory GB per instance * running instances * running hours) / 730)
+billable GB/month = ceil(sum(memory GB * instances * running hours) / 730)
 ```
 
-SAP rounds after summing Cloud Foundry Runtime usage at global-account level.
-For an isolated estimate, round this deployment by itself. For a customer global
-account that already runs other CF apps, add this deployment's GB-hours to the
-account total before rounding.
+SAP rounds after summing Cloud Foundry Runtime usage at global-account level. For
+a standalone estimate, round this app by itself; for a customer account, add this
+app's GB-hours to the existing CF runtime usage before rounding.
 
-SAP Discovery Center pricing in EUR at the time this guide was written:
+SAP Discovery Center prices in EUR at the time this guide was written:
 
 | Service | Plan | Metric | Cloud Credits / BTPEA / subscription | Pay-as-you-go |
 | --- | --- | --- | --- | --- |
 | SAP BTP, Cloud Foundry Runtime | Standard | GB Memory per month | `85.00 EUR` | `110.50 EUR` |
-| SAP BTP, Cloud Foundry Runtime | Free | GB Memory per month | `0.00 EUR` | `0.00 EUR` |
 | SAP Job Scheduling Service | Standard | 10,000 job executions per month | `14.00 EUR` | `18.20 EUR` |
-| SAP Job Scheduling Service | Free | Job executions | `0.00 EUR` | `0.00 EUR` |
 
-Use the SAP Discovery Center or the BTP cost estimator for the customer's
-contract, currency, and region before quoting a final price. Free tier plans are
-useful for trials but have limits, community support only, and no SLA.
+Free tier plans may be `0.00 EUR`, but they have limits, community support only,
+and no SLA. Recheck SAP Discovery Center or the BTP cost estimator for the
+customer's contract, currency, and region before quoting a final price.
 
-Typical monthly estimates for this MCP deployment:
+Typical estimates for this deployment:
 
 | Scenario | Calculation | Billable CF runtime | Runtime cost at `85.00 EUR` | Runtime cost at `110.50 EUR` |
 | --- | --- | --- | --- | --- |
 | Recommended semantic app, always on | `1 GB * 1 instance * 730 h / 730` | `1 GB/month` | `85.00 EUR/month` | `110.50 EUR/month` |
 | FTS-only fallback, one always-on instance | `0.5 GB * 1 instance * 730 h / 730`, rounded up | `1 GB/month` | `85.00 EUR/month` | `110.50 EUR/month` |
-| Recommended semantic app, second instance for one 24 h peak | `(1 GB * 730 h + 1 GB * 24 h) / 730`, rounded up | `2 GB/month` | `170.00 EUR/month` | `221.00 EUR/month` |
 | Recommended semantic app, two instances always on | `1 GB * 2 instances * 730 h / 730` | `2 GB/month` | `170.00 EUR/month` | `221.00 EUR/month` |
-| Dev/test usage, one semantic instance, 8 h/day for 20 days | `1 GB * 160 h / 730`, rounded up | `1 GB/month` | `85.00 EUR/month` | `110.50 EUR/month` |
+| Temporary second semantic instance for one 24 h peak | `(1 GB * 730 h + 1 GB * 24 h) / 730`, rounded up | `2 GB/month` | `170.00 EUR/month` | `221.00 EUR/month` |
 
-For one always-on instance, FTS-only does not lower the Cloud Foundry Runtime
-bill in this standalone estimate because both `512M` and `1024M` round to
-`1 GB/month`. It can still help when disk quota, image size, startup memory, or
-aggregate account-level rounding are the real constraint.
+FTS-only is therefore not a cost optimization for one always-on instance: both
+`512M` and `1024M` round to `1 GB/month`. It is mainly useful when disk quota,
+image size, startup memory, or aggregate account-level rounding is the real
+constraint.
 
-Daily image refresh adds two small cost components:
-
-- SAP Job Scheduling Service: the `free` plan is enough for one daily refresh
-  when available. On the `standard` plan, one daily refresh is about 30-31 job
-  executions per month, which fits into one 10,000-execution block.
-- Deployer CF task: the deployer app is stopped between runs. The task reserves
-  its configured memory only while the refresh task runs, so estimate it with
-  the same GB-hour formula if the runtime is material in the customer's account.
-
-Disk quota is operational headroom for the Docker image filesystem and is not
-listed by SAP Discovery Center as the Cloud Foundry Runtime billing metric for
-this service. Private container registries, log retention, alerting, and other
-bound BTP services can add separate costs.
+Daily image refresh normally adds little: the Job Scheduling Service `free` plan
+is enough for one daily refresh when available, while the `standard` plan charges
+one 10,000-execution block for roughly 30-31 monthly runs. The deployer app is
+stopped between runs; its CF task reserves memory only while the task runs. Disk
+quota is operational headroom, not the Discovery Center billing metric for Cloud
+Foundry Runtime. Private registries, log retention, alerting, and other bound BTP
+services can add separate costs.
 
 ## Prerequisites
 

--- a/docs/BTP-CF-DEPLOYMENT.md
+++ b/docs/BTP-CF-DEPLOYMENT.md
@@ -86,6 +86,9 @@ Without embeddings:
 - BM25/FTS search, fetch, and online sources still work.
 - The image is smaller and faster to build.
 - Semantic reranking is not available.
+- This is a quota and startup fallback, not the recommended cost-saving mode for
+  a single always-on CF app. With SAP's GB/month rounding, `512M` for a full
+  month still rounds up to `1 GB/month`.
 
 Recommended semantic defaults:
 
@@ -100,6 +103,10 @@ FTS-only fallback defaults:
 - disk quota: `4096M`
 - instances: `1`
 - `MCP_PRELOAD_EMBEDDINGS=false`
+
+Use these fallback values only when the semantic image does not fit the target
+space or embedding preload is too tight for available memory. Keep the semantic
+profile when the goal is search quality and the target space can fit it.
 
 ## Cost Estimate
 
@@ -139,10 +146,15 @@ Typical monthly estimates for this MCP deployment:
 | Scenario | Calculation | Billable CF runtime | Runtime cost at `85.00 EUR` | Runtime cost at `110.50 EUR` |
 | --- | --- | --- | --- | --- |
 | Recommended semantic app, always on | `1 GB * 1 instance * 730 h / 730` | `1 GB/month` | `85.00 EUR/month` | `110.50 EUR/month` |
-| FTS-only fallback, always on | `0.5 GB * 1 instance * 730 h / 730`, rounded up | `1 GB/month` | `85.00 EUR/month` | `110.50 EUR/month` |
+| FTS-only fallback, one always-on instance | `0.5 GB * 1 instance * 730 h / 730`, rounded up | `1 GB/month` | `85.00 EUR/month` | `110.50 EUR/month` |
 | Recommended semantic app, second instance for one 24 h peak | `(1 GB * 730 h + 1 GB * 24 h) / 730`, rounded up | `2 GB/month` | `170.00 EUR/month` | `221.00 EUR/month` |
 | Recommended semantic app, two instances always on | `1 GB * 2 instances * 730 h / 730` | `2 GB/month` | `170.00 EUR/month` | `221.00 EUR/month` |
 | Dev/test usage, one semantic instance, 8 h/day for 20 days | `1 GB * 160 h / 730`, rounded up | `1 GB/month` | `85.00 EUR/month` | `110.50 EUR/month` |
+
+For one always-on instance, FTS-only does not lower the Cloud Foundry Runtime
+bill in this standalone estimate because both `512M` and `1024M` round to
+`1 GB/month`. It can still help when disk quota, image size, startup memory, or
+aggregate account-level rounding are the real constraint.
 
 Daily image refresh adds two small cost components:
 
@@ -438,9 +450,9 @@ Parameter guidance:
 | Parameter | Default | Why it matters |
 | --- | --- | --- |
 | `memory` / `-m` | `1024M` | Runtime RAM per app instance. Embedding preload keeps the model resident so the first semantic query is not slow. |
-| `disk-quota` / `disk_quota` / `-k` | `6144M` | CF Docker apps need enough disk for the uncompressed image filesystem. Use `4096M` only for FTS-only fallback. |
+| `disk-quota` / `disk_quota` / `-k` | `6144M` | CF Docker apps need enough disk for the uncompressed image filesystem. Use `4096M` only for FTS-only fallback when the semantic image is too large. |
 | `instances` / `-i` | `1` | One instance minimizes quota use. Use more only when you need availability during deploys or platform maintenance. |
-| `MCP_PRELOAD_EMBEDDINGS` | `true` | Loads the embedding model at startup. Set false for FTS-only or if you deliberately prefer lazy first-query loading. |
+| `MCP_PRELOAD_EMBEDDINGS` | `true` | Loads the embedding model at startup. Set false only when startup memory is too tight or you intentionally use an FTS-only image. |
 | `health-check-type` | `http` | Confirms the app can serve `/health`, not only that a port opened. |
 | `timeout` / `-t` | `180-240` | Large images can take longer to pull/start. The allowed maximum is foundation-specific. |
 
@@ -450,7 +462,9 @@ If startup fails, tune in this order:
    problems.
 2. Increase `memory` if the app exits during embedding preload.
 3. Set `MCP_PRELOAD_EMBEDDINGS=false` only if you need to reduce startup memory.
-4. Use an FTS-only image only when quota is too tight for semantic search.
+4. Use an FTS-only image only when quota is too tight for semantic search. Do
+   not switch to FTS-only expecting lower monthly runtime cost for one always-on
+   instance; SAP's GB/month rounding usually makes it the same `1 GB/month`.
 
 Do not run `MCP_VARIANT=sap-docs npm run setup && npm run build` inside a small
 CF staging container unless you intentionally choose the Node.js buildpack path.
@@ -762,7 +776,8 @@ Increase `disk-quota` first. Semantic images need `6144M` by default.
 
 The app exits during startup with embeddings enabled:
 Increase memory or set `MCP_PRELOAD_EMBEDDINGS=false`. Use FTS-only only if
-quota is too tight for semantic search.
+quota is too tight for semantic search; it is usually not cheaper for one
+always-on instance.
 
 Node.js buildpack staging fails after a long upload:
 Use Docker image deployment. The current full corpus is too large for the tested

--- a/docs/BTP-CF-DEPLOYMENT.md
+++ b/docs/BTP-CF-DEPLOYMENT.md
@@ -288,13 +288,43 @@ cf delete mcp-sap-docs -f -r
 
 ## Verify
 
-Get the route and current app state:
+First choose the app name:
+
+- MTA deployment: use the module name from `mta.yaml`, by default
+  `mcp-sap-docs-server`.
+- Direct `cf push` trial: use the app name passed to `cf push`, by default
+  `mcp-sap-docs`.
+
+For MTA, the app name comes from:
+
+```yaml
+modules:
+  - name: mcp-sap-docs-server
+```
+
+The route comes from `mta-overrides.mtaext` if you configured one:
+
+```yaml
+routes:
+  - route: mcp-sap-docs.<your-cf-domain>
+```
+
+If you did not configure a route, use the route shown by `cf app`.
+
+Get the route and current app state for the MTA deployment:
+
+```bash
+cf app mcp-sap-docs-server
+```
+
+For the direct `cf push` trial, use:
 
 ```bash
 cf app mcp-sap-docs
 ```
 
-Health check on macOS/Linux:
+Health check on macOS/Linux, replacing `<route>` with the route shown by
+`cf app` or the route from `mta-overrides.mtaext`:
 
 ```bash
 curl -sS https://<route>/health

--- a/docs/BTP-CF-DEPLOYMENT.md
+++ b/docs/BTP-CF-DEPLOYMENT.md
@@ -216,23 +216,14 @@ routes:
   - route: mcp-sap-docs.<your-cf-domain>
 ```
 
-Build and deploy on macOS/Linux:
+Build and deploy on macOS/Linux or Windows PowerShell:
 
 ```bash
-mbt build
-MTAR="$(ls -t mta_archives/mcp-sap-docs-btp-cf_*.mtar | head -n 1)"
-cf deploy "$MTAR" -e mta-overrides.mtaext
+npm run btp:deploy:mta
 ```
 
-Build and deploy on Windows PowerShell:
-
-```powershell
-mbt build
-$Mtar = Get-ChildItem -Path "mta_archives" -Filter "mcp-sap-docs-btp-cf_*.mtar" |
-  Sort-Object LastWriteTime -Descending |
-  Select-Object -First 1
-cf deploy $Mtar.FullName -e mta-overrides.mtaext
-```
+This helper runs `mbt build`, selects the newest MTAR from `mta_archives`, and
+deploys it with `mta-overrides.mtaext` when that file exists.
 
 If you do not create `mta-overrides.mtaext`, CF/MTA can still deploy the app,
 but it may assign a generated route.
@@ -427,22 +418,10 @@ cf push mcp-sap-docs `
 If you use MTA for route and service binding ownership, prefer redeploying the
 MTA instead of direct `cf push`:
 
-macOS/Linux:
+macOS/Linux or Windows PowerShell:
 
 ```bash
-mbt build
-MTAR="$(ls -t mta_archives/mcp-sap-docs-btp-cf_*.mtar | head -n 1)"
-cf deploy "$MTAR" -e mta-overrides.mtaext
-```
-
-Windows PowerShell:
-
-```powershell
-mbt build
-$Mtar = Get-ChildItem -Path "mta_archives" -Filter "mcp-sap-docs-btp-cf_*.mtar" |
-  Sort-Object LastWriteTime -Descending |
-  Select-Object -First 1
-cf deploy $Mtar.FullName -e mta-overrides.mtaext
+npm run btp:deploy:mta
 ```
 
 If you already set up the deployer app from the next section, you can also run

--- a/docs/BTP-CF-DEPLOYMENT.md
+++ b/docs/BTP-CF-DEPLOYMENT.md
@@ -111,17 +111,15 @@ profile when the goal is search quality and the target space can fit it.
 ## Cost Estimate
 
 SAP BTP, Cloud Foundry Runtime is billed by reserved runtime memory, not actual
-heap usage or request count. Request load changes the bill only when it makes you
-increase memory, instances, or running hours. A stopped app does not reserve
-runtime memory.
+heap usage or request count. For this deployment, the important input is the
+configured CF memory per running app instance.
 
 ```text
 billable GB/month = ceil(sum(memory GB * instances * running hours) / 730)
 ```
 
-SAP rounds after summing Cloud Foundry Runtime usage at global-account level. For
-a standalone estimate, round this app by itself; for a customer account, add this
-app's GB-hours to the existing CF runtime usage before rounding.
+SAP rounds after summing Cloud Foundry Runtime usage at global-account level. A
+stopped app does not reserve runtime memory.
 
 SAP Discovery Center prices in EUR at the time this guide was written:
 
@@ -134,26 +132,23 @@ Free tier plans may be `0.00 EUR`, but they have limits, community support only,
 and no SLA. Recheck SAP Discovery Center or the BTP cost estimator for the
 customer's contract, currency, and region before quoting a final price.
 
-Typical estimates for this deployment:
+Simple standalone estimate:
 
 | Scenario | Calculation | Billable CF runtime | Runtime cost at `85.00 EUR` | Runtime cost at `110.50 EUR` |
 | --- | --- | --- | --- | --- |
 | Recommended semantic app, always on | `1 GB * 1 instance * 730 h / 730` | `1 GB/month` | `85.00 EUR/month` | `110.50 EUR/month` |
 | FTS-only fallback, one always-on instance | `0.5 GB * 1 instance * 730 h / 730`, rounded up | `1 GB/month` | `85.00 EUR/month` | `110.50 EUR/month` |
-| Recommended semantic app, two instances always on | `1 GB * 2 instances * 730 h / 730` | `2 GB/month` | `170.00 EUR/month` | `221.00 EUR/month` |
-| Temporary second semantic instance for one 24 h peak | `(1 GB * 730 h + 1 GB * 24 h) / 730`, rounded up | `2 GB/month` | `170.00 EUR/month` | `221.00 EUR/month` |
 
-FTS-only is therefore not a cost optimization for one always-on instance: both
-`512M` and `1024M` round to `1 GB/month`. It is mainly useful when disk quota,
-image size, startup memory, or aggregate account-level rounding is the real
-constraint.
+FTS-only is not a cost optimization for one always-on instance: both `512M` and
+`1024M` round to `1 GB/month`. Use FTS-only only when disk quota, image size, or
+startup memory is the real constraint. If you add more CF app instances for
+availability or load, multiply the reserved memory by the number of instances.
 
 Daily image refresh normally adds little: the Job Scheduling Service `free` plan
 is enough for one daily refresh when available, while the `standard` plan charges
-one 10,000-execution block for roughly 30-31 monthly runs. The deployer app is
-stopped between runs; its CF task reserves memory only while the task runs. Disk
-quota is operational headroom, not the Discovery Center billing metric for Cloud
-Foundry Runtime. Private registries, log retention, alerting, and other bound BTP
+one 10,000-execution block for roughly 30-31 monthly runs. Disk quota is
+operational headroom, not the Discovery Center billing metric for Cloud Foundry
+Runtime. Private registries, log retention, alerting, and other bound BTP
 services can add separate costs.
 
 ## Prerequisites

--- a/docs/BTP-CF-DEPLOYMENT.md
+++ b/docs/BTP-CF-DEPLOYMENT.md
@@ -61,7 +61,10 @@ Reference docs:
 
 - [Cloud Foundry: deploying an app based on a Docker image](https://docs.cloudfoundry.org/devguide/deploy-apps/push-docker.html)
 - [SAP BTP: deploy Docker images in the Cloud Foundry environment](https://help.sap.com/docs/btp/sap-business-technology-platform/deploy-docker-images-in-cloud-foundry-environment)
+- [SAP BTP: service plans and metering for Cloud Foundry Runtime](https://help.sap.com/docs/cf-runtime/cloud-foundry-runtime/service-plans-and-metering-for-cloud-foundry-runtime)
 - [Cloud Foundry: deploying large apps](https://docs.cloudfoundry.org/devguide/deploy-apps/large-app-deploy.html)
+- [SAP Discovery Center: SAP BTP, Cloud Foundry Runtime](https://discovery-center.cloud.sap/serviceCatalog/257fac1c-88aa-415b-8ea8-c96282c9a19b)
+- [SAP Discovery Center: SAP Job Scheduling Service](https://discovery-center.cloud.sap/serviceCatalog/0b70a063-d6ec-4775-8adb-2b01312b979f)
 - [SAP Job Scheduling Service](https://help.sap.com/doc/234ab5b017b14bfa9d96152c5d9335e7/Cloud/en-US/jobscheduler.pdf)
 - [Cloud Foundry: running tasks in your apps](https://docs.cloudfoundry.org/devguide/using-tasks.html)
 
@@ -97,6 +100,63 @@ FTS-only fallback defaults:
 - disk quota: `4096M`
 - instances: `1`
 - `MCP_PRELOAD_EMBEDDINGS=false`
+
+## Cost Estimate
+
+SAP BTP, Cloud Foundry Runtime is metered on reserved runtime memory, not on
+actual heap usage or request count. Load changes the cost only when you scale the
+deployment by increasing memory per instance, increasing the number of running
+instances, or running it for more hours. A stopped app does not reserve runtime
+memory.
+
+SAP documents the monthly Cloud Foundry Runtime calculation as:
+
+```text
+billable GB/month =
+  ceil(sum(memory GB per instance * running instances * running hours) / 730)
+```
+
+SAP rounds after summing Cloud Foundry Runtime usage at global-account level.
+For an isolated estimate, round this deployment by itself. For a customer global
+account that already runs other CF apps, add this deployment's GB-hours to the
+account total before rounding.
+
+SAP Discovery Center pricing in EUR at the time this guide was written:
+
+| Service | Plan | Metric | Cloud Credits / BTPEA / subscription | Pay-as-you-go |
+| --- | --- | --- | --- | --- |
+| SAP BTP, Cloud Foundry Runtime | Standard | GB Memory per month | `85.00 EUR` | `110.50 EUR` |
+| SAP BTP, Cloud Foundry Runtime | Free | GB Memory per month | `0.00 EUR` | `0.00 EUR` |
+| SAP Job Scheduling Service | Standard | 10,000 job executions per month | `14.00 EUR` | `18.20 EUR` |
+| SAP Job Scheduling Service | Free | Job executions | `0.00 EUR` | `0.00 EUR` |
+
+Use the SAP Discovery Center or the BTP cost estimator for the customer's
+contract, currency, and region before quoting a final price. Free tier plans are
+useful for trials but have limits, community support only, and no SLA.
+
+Typical monthly estimates for this MCP deployment:
+
+| Scenario | Calculation | Billable CF runtime | Runtime cost at `85.00 EUR` | Runtime cost at `110.50 EUR` |
+| --- | --- | --- | --- | --- |
+| Recommended semantic app, always on | `1 GB * 1 instance * 730 h / 730` | `1 GB/month` | `85.00 EUR/month` | `110.50 EUR/month` |
+| FTS-only fallback, always on | `0.5 GB * 1 instance * 730 h / 730`, rounded up | `1 GB/month` | `85.00 EUR/month` | `110.50 EUR/month` |
+| Recommended semantic app, second instance for one 24 h peak | `(1 GB * 730 h + 1 GB * 24 h) / 730`, rounded up | `2 GB/month` | `170.00 EUR/month` | `221.00 EUR/month` |
+| Recommended semantic app, two instances always on | `1 GB * 2 instances * 730 h / 730` | `2 GB/month` | `170.00 EUR/month` | `221.00 EUR/month` |
+| Dev/test usage, one semantic instance, 8 h/day for 20 days | `1 GB * 160 h / 730`, rounded up | `1 GB/month` | `85.00 EUR/month` | `110.50 EUR/month` |
+
+Daily image refresh adds two small cost components:
+
+- SAP Job Scheduling Service: the `free` plan is enough for one daily refresh
+  when available. On the `standard` plan, one daily refresh is about 30-31 job
+  executions per month, which fits into one 10,000-execution block.
+- Deployer CF task: the deployer app is stopped between runs. The task reserves
+  its configured memory only while the refresh task runs, so estimate it with
+  the same GB-hour formula if the runtime is material in the customer's account.
+
+Disk quota is operational headroom for the Docker image filesystem and is not
+listed by SAP Discovery Center as the Cloud Foundry Runtime billing metric for
+this service. Private container registries, log retention, alerting, and other
+bound BTP services can add separate costs.
 
 ## Prerequisites
 

--- a/docs/BTP-CF-DEPLOYMENT.md
+++ b/docs/BTP-CF-DEPLOYMENT.md
@@ -35,6 +35,28 @@ compliance rules require staging from source. For the current full `sap-docs`
 corpus, the Node.js buildpack path is not recommended because staging has to
 handle a large app package, dependencies, droplet copy, and compression.
 
+## Deployment Options and Tradeoffs
+
+There are two separate decisions:
+
+- How the app is deployed to CF: MTA or direct `cf push`.
+- Where the image comes from: maintained public image or your own registry.
+
+Recommended default: deploy the maintained semantic image with MTA. Use direct
+`cf push` first when you want a quick trial in a dev space.
+
+| Option | Best for | Upsides | Downsides |
+| --- | --- | --- | --- |
+| Maintained image with MTA | Standard setup and customer handover | Repeatable descriptor, stable app/module name, route and resource settings in versioned files, ready for later service bindings such as XSUAA or Job Scheduling Service. | Requires `mbt` and the CF deploy plugin, creates an MTA deployment record, and is slightly more ceremony than a one-line trial deploy. |
+| Maintained image with direct `cf push` | Fast technical validation | Quickest way to test quota, image pull, startup, route, and `/health`; no MTAR build; easy to delete after the trial. | Not an MTA-managed deployment, so route/resource changes live in command history or a manifest; later service bindings and lifecycle operations are less structured. |
+| Own registry image | Organizations that require private registries or controlled image promotion | Full control over image provenance, vulnerability scanning, approval gates, retention, and digest pinning. | You must build, store, publish, secure, and refresh the image yourself; CF must be able to pull from that registry. |
+| Node.js buildpack package | Only when Docker images are not allowed | Uses source/package staging instead of Docker image execution. | Not recommended for the full `sap-docs` corpus: tested packages failed during large-app staging/droplet copy/compression, and staging takes much longer than pulling the prepared image. |
+| Job Scheduling Service refresh | Keeping a moving image tag current in CF | Runs fully inside BTP CF, visible in the customer's space, and avoids adding a refresh endpoint to the public MCP server. | Needs a scheduler service instance, a small deployer app, deploy credentials that work without browser SSO, and extra temporary memory for CF tasks. |
+
+In quota-constrained spaces, do not run the direct `cf push` trial app and the
+MTA app at the same time unless you have enough memory for both. The semantic app
+uses `1024M` memory and `6144M` disk.
+
 Reference docs:
 
 - [Cloud Foundry: deploying an app based on a Docker image](https://docs.cloudfoundry.org/devguide/deploy-apps/push-docker.html)
@@ -145,6 +167,24 @@ digest only when you intentionally want a fixed, reproducible deployment.
 
 ## Deploy with MTA
 
+Use this path for the real setup after the fast trial has proven that the image
+starts in the target CF space. MTA keeps the deployable configuration in
+`mta.yaml` and optional `.mtaext` overrides, which makes handover and later
+changes more predictable.
+
+MTA is the better long-term option when you want stable routes, controlled
+resource settings, service bindings, and a clean `cf undeploy` lifecycle. The
+tradeoff is that the deployment has an extra build/deploy step and the resulting
+app name comes from the MTA module (`mcp-sap-docs-server` by default), not from a
+one-off `cf push` command.
+
+If you already created a trial app named `mcp-sap-docs` with direct `cf push`,
+delete it before deploying the MTA in small free-tier spaces:
+
+```bash
+cf delete mcp-sap-docs -f -r
+```
+
 Copy the extension template and adapt it for your landscape.
 
 macOS/Linux:
@@ -201,6 +241,15 @@ but it may assign a generated route.
 
 Use direct `cf push` when you want to quickly validate CF quota, route, and image
 startup before using MTA. This does not create an MTA deployment record.
+
+This is the simplest first test because it exercises the important runtime
+facts: CF can pull the image, the semantic corpus fits into disk quota, the app
+starts with `1024M` memory, and `/health` is reachable.
+
+The downside is operational: a direct push is just one CF app. It is fine for a
+trial or manual refresh, but it does not give you an MTA-managed deployment
+record, module/resource model, or a natural place to add future service bindings.
+For a customer setup, switch to MTA after this test passes.
 
 Using the manifest:
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build:embeddings": "npm run build:tsc && node dist/scripts/build-embeddings.js",
     "btp:build-image": "bash scripts/btp/build-ghcr-image.sh",
     "btp:build-image:push": "bash scripts/btp/build-ghcr-image.sh --push",
-    "btp:deploy:mta": "bash scripts/btp/deploy-cf-mta.sh",
+    "btp:deploy:mta": "node scripts/btp/deploy-cf-mta.mjs",
     "start": "node dist/src/server.js",
     "start:http": "node dist/src/http-server.js",
     "start:streamable": "node dist/src/streamable-http-server.js",

--- a/scripts/btp/deploy-cf-mta.mjs
+++ b/scripts/btp/deploy-cf-mta.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+function printHelp() {
+  console.log(`Build and deploy the sap-docs MTA archive to the current CF target.
+
+Environment:
+  MTA_EXT   Optional MTA extension descriptor (default: mta-overrides.mtaext)
+
+Examples:
+  npm run btp:deploy:mta
+  MTA_EXT=my-overrides.mtaext npm run btp:deploy:mta
+  $env:MTA_EXT="my-overrides.mtaext"; npm run btp:deploy:mta
+`);
+}
+
+function run(command, args) {
+  const result = spawnSync(command, args, {
+    stdio: "inherit",
+    shell: process.platform === "win32",
+  });
+
+  if (result.error) {
+    console.error(`Failed to run ${command}: ${result.error.message}`);
+    process.exit(1);
+  }
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+function newestMtar() {
+  const archiveDir = "mta_archives";
+  if (!existsSync(archiveDir)) {
+    return null;
+  }
+
+  return readdirSync(archiveDir)
+    .filter((file) => /^mcp-sap-docs-btp-cf_.*\.mtar$/.test(file))
+    .map((file) => {
+      const path = join(archiveDir, file);
+      return { path, mtimeMs: statSync(path).mtimeMs };
+    })
+    .sort((a, b) => b.mtimeMs - a.mtimeMs)[0]?.path ?? null;
+}
+
+if (process.argv.includes("-h") || process.argv.includes("--help")) {
+  printHelp();
+  process.exit(0);
+}
+
+const mtaExt = process.env.MTA_EXT || "mta-overrides.mtaext";
+
+run("mbt", ["build"]);
+
+const mtar = newestMtar();
+if (!mtar) {
+  console.error("No MTAR archive found under mta_archives/.");
+  process.exit(1);
+}
+
+console.log(`Deploying ${mtar}`);
+if (existsSync(mtaExt)) {
+  run("cf", ["deploy", mtar, "-e", mtaExt]);
+} else {
+  console.warn(`Extension descriptor ${mtaExt} not found; deploying without -e.`);
+  run("cf", ["deploy", mtar]);
+}


### PR DESCRIPTION
## Goal
Document the practical upsides and downsides of the supported BTP CF deployment paths before customer handover.

## Changes
- Add a deployment options and tradeoffs table covering MTA, direct cf push, own registry images, Node.js buildpack packaging, and Job Scheduling Service refresh.
- Expand the MTA section with why it is the recommended long-term/customer setup.
- Expand the cf push section with why it is best as a fast trial and what it does not manage.
- Call out quota-constrained spaces so users do not run the trial app and MTA app at the same time unintentionally.

## Validation
- npm run build:tsc
- git diff --check