### PR TITLE
feat: enrich SAP Help with support content

### DIFF
--- a/src/lib/BaseServerHandler.ts
+++ b/src/lib/BaseServerHandler.ts
@@ -283,7 +283,7 @@ Sample-heavy OFFLINE sources (controlled by \`includeSamples\`; great for implem
 • abap-platform-reuse-services (offline, samples): RAP reuse services examples (number ranges, change documents, mail, Adobe Forms, ...).
 
 OPTIONAL ONLINE SOURCES (when includeOnline=true):
-• sap-help (online): SAP Help Portal product documentation (official, broad scope).
+• sap-help (online): SAP Help Portal product documentation (official, broad scope). Also includes a lower-priority, capped Support Content enrichment for old SAPWiki-style material; those hits remain sap-help results and carry metadata.sourceSubkind="support_content".
 • sap-community (online): SAP Community blogs + Q&A + troubleshooting (practical, quality varies).
 • software-heroes (online): Software Heroes ABAP/RAP articles & tutorials (searched in EN+DE, deduplicated by URL; feed search is disabled).
 
@@ -316,6 +316,7 @@ RETURNS (JSON array of results, each containing):
 • library_id: Source library identifier
 • metadata.source: Source ID (abap-docs-standard, sap-help, etc.)
 • metadata.sourceKind: "offline" | "sap_help" | "sap_community" | "software_heroes"
+• metadata.sourceSubkind: Optional refinement; currently "support_content" for legacy SAP Help Support Content hits.
 
 TYPICAL WORKFLOW:
 1. search(query="your ABAP/RAP question")

--- a/src/lib/sapHelp.ts
+++ b/src/lib/sapHelp.ts
@@ -38,6 +38,15 @@ export const ABAP_HELP_PRODUCTS: Record<'standard' | 'cloud', string> = {
 const ID_PREFIX = "sap-help-";
 const VERSION_SEP = "~";
 
+export interface SapHelpSearchOptions {
+  /**
+   * By default SAP Help search relaxes product/version filters when a scoped query returns nothing,
+   * so the online leg is never lost. Set to false for auxiliary product legs where falling back to
+   * unscoped SAP Help would duplicate or pollute another source.
+   */
+  relax?: boolean;
+}
+
 /**
  * Structured citation for a SAP Help document: the stable cross-release identity
  * (`loio`), the resolved page title/url, and the exact deliverable build the
@@ -190,15 +199,23 @@ export async function resolveHelpResults(
   return { results, usedVersion: requested }; // all empty — usedVersion is unused downstream
 }
 
-export async function searchSapHelp(query: string, version?: string, product?: string): Promise<SearchResponse> {
+export async function searchSapHelp(
+  query: string,
+  version?: string,
+  product?: string,
+  options: SapHelpSearchOptions = {}
+): Promise<SearchResponse> {
   try {
     const requested = (version ?? "").trim();
     const scope = (product ?? "").trim();
+    const relax = options.relax ?? true;
     // Resolve the two optional filters via the relaxation ladder: it relaxes a wrong/empty PRODUCT
     // before the caller's VERSION pin and never goes below unscoped-latest, so the leg is never lost
     // and a bad product never silently swaps the requested release. `usedVersion` then drives id
     // encoding, so a later fetch follows whichever release actually answered. See resolveHelpResults.
-    const { results, usedVersion } = await resolveHelpResults(fetchHelpResults, query, requested, scope);
+    const { results, usedVersion } = relax
+      ? await resolveHelpResults(fetchHelpResults, query, requested, scope)
+      : { results: await fetchHelpResults(query, requested, scope), usedVersion: requested };
 
     if (!results.length) {
       return {

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -22,10 +22,15 @@ export type SearchResult = {
   citation?: {
     loio?: string;
     product?: string;
+    productId?: string;
     /** Pinnable release token (e.g. "2025.001") — pass back as `version` to re-pin the same release. */
     versionId?: string;
     /** Human display label of the release (e.g. "2025 FPS01 (Feb 2026)") — for showing, not filtering. */
     version?: string;
+    /** Optional SAP Help subkind for legacy Support Content hits. Not a separate source. */
+    sourceSubkind?: 'support_content';
+    supportContent?: true;
+    legacyKnowledge?: true;
   };
   // Debug info for ranking analysis
   debug?: {
@@ -75,6 +80,12 @@ const RRF_WEIGHTS = {
   semantic: CONFIG.EMBEDDING_WEIGHT, // Embedding-based semantic results (default 0.7)
 };
 
+const SUPPORT_CONTENT_PRODUCT = "SUPPORT_CONTENT";
+const SUPPORT_CONTENT_VERSION = "1.0";
+// Internal auxiliary leg weight: old SAPWiki-style Support Content is useful, but deliberately
+// secondary and still returned as normal SAP Help (`sourceKind: "sap_help"`).
+const SUPPORT_CONTENT_RRF_WEIGHT = 0.65;
+
 /**
  * Reciprocal Rank Fusion scoring
  * RRF(rank) = 1 / (k + rank) where k=60 is standard
@@ -118,7 +129,8 @@ function dedupeKey(r: SearchResult): string {
     // so RRF fusion accumulates both scores for the same document.
     return `offline:${r.sourceId}:${r.id}`;
   }
-  // For online results, use canonical URL
+  // For online results, use canonical URL. Regular SAP Help and the lower-weight
+  // Support Content enrichment share the SAP Help source identity.
   return `online:${r.sourceKind}:${canonicalUrl(r.path || r.id)}`;
 }
 
@@ -236,6 +248,17 @@ function normalizeSourceFilter(source: string): string {
   return source.replace(/^\/+/, '').trim();
 }
 
+function isSupportContentResult(result: ApiSearchResult): boolean {
+  const productId = String(result.metadata?.productId ?? "").toUpperCase();
+  const product = String(result.metadata?.product ?? "").toUpperCase();
+  const url = result.url || "";
+  return (
+    productId === SUPPORT_CONTENT_PRODUCT ||
+    product === "SUPPORT CONTENT" ||
+    url.includes("/docs/SUPPORT_CONTENT/")
+  );
+}
+
 // Create a promise that rejects after timeout
 function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
   return Promise.race([
@@ -256,7 +279,8 @@ function processOnlineSource(
   sourceKind: SearchResult['sourceKind'],
   rrfWeight: number,
   boost: number,
-  maxResults = 10
+  maxResults = 10,
+  resultFilter?: (result: ApiSearchResult) => boolean
 ): SearchResult[] {
   if (settled.status !== 'fulfilled') {
     const reason = (settled as PromiseRejectedResult).reason;
@@ -270,15 +294,21 @@ function processOnlineSource(
     console.warn(`⚠️ [${sourceName}] ${response.error}`);
   }
 
-  if (!response?.results || response.results.length === 0) {
+  const filteredResults = response?.results
+    ? (resultFilter ? response.results.filter(resultFilter) : response.results)
+    : [];
+
+  if (filteredResults.length === 0) {
     console.log(`⚠️ [${sourceName}] No results`);
     return [];
   }
 
-  const results: SearchResult[] = response.results.slice(0, maxResults).map((r, idx) => {
+  const results: SearchResult[] = filteredResults.slice(0, maxResults).map((r, idx) => {
     const rank = idx + 1;
     const rrfScore = rrf(rank) * rrfWeight;
     const finalScore = rrfScore * (1 + boost);
+    const isSapHelp = sourceKind === 'sap_help';
+    const isSupportContent = isSapHelp && isSupportContentResult(r);
 
     return {
       id: r.id || `${sourceKind}-${idx}`,
@@ -290,15 +320,23 @@ function processOnlineSource(
       finalScore,
       sourceKind,
       // SAP Help hits carry loio/product/versionId/version in their metadata (set by searchSapHelp);
-      // preserve it as a citation so the MCP layer exposes it in the result metadata. versionId is
-      // the pinnable token — without it the agent only sees the display string and can't re-pin.
-      ...(sourceKind === 'sap_help' && r.metadata
+      // preserve it as a citation so the MCP layer exposes it in the result metadata. Support
+      // Content remains SAP Help publicly, with subkind flags for provenance.
+      ...(isSapHelp && r.metadata
         ? {
             citation: {
               loio: r.metadata.loio ?? undefined,
               product: r.metadata.product,
+              productId: r.metadata.productId,
               versionId: r.metadata.versionId,
-              version: r.metadata.version
+              version: r.metadata.version,
+              ...(isSupportContent
+                ? {
+                    sourceSubkind: 'support_content' as const,
+                    supportContent: true as const,
+                    legacyKnowledge: true as const
+                  }
+                : {})
             }
           }
         : {}),
@@ -660,10 +698,21 @@ export async function search(
   
   if (includeOnline) {
     console.log(`🌐 [ONLINE] Starting online searches for "${query}" (${ONLINE_TIMEOUT_MS}ms timeout)...`);
+    const includeSupportContent = !sapHelpProduct;
     
     const onlineSearches = await Promise.allSettled([
       // SAP Help search with timeout (version filter applies to this source only)
       withTimeout(searchSapHelp(query, version, sapHelpProduct), ONLINE_TIMEOUT_MS, 'SAP Help search'),
+      // SAP Support Content contains old SAPWiki-style material. It is queried strictly
+      // against product SUPPORT_CONTENT and kept lower-weight/capped so it complements
+      // regular SAP Help instead of replacing it.
+      includeSupportContent
+        ? withTimeout(
+            searchSapHelp(query, SUPPORT_CONTENT_VERSION, SUPPORT_CONTENT_PRODUCT, { relax: false }),
+            ONLINE_TIMEOUT_MS,
+            'SAP Support Content search'
+          )
+        : Promise.resolve({ results: [] } satisfies SearchResponse),
       // SAP Community search with timeout  
       withTimeout(searchCommunity(query), ONLINE_TIMEOUT_MS, 'SAP Community search'),
       // Software-Heroes search with timeout - search both EN and DE languages
@@ -706,9 +755,27 @@ export async function search(
     
     // Process each online source using shared helper
     onlineResults.push(
-      ...processOnlineSource(onlineSearches[0], 'SAP Help', 'sap_help', RRF_WEIGHTS.sap_help, onlineBoost),
-      ...processOnlineSource(onlineSearches[1], 'SAP Community', 'sap_community', RRF_WEIGHTS.sap_community, onlineBoost * 0.5),
-      ...processOnlineSource(onlineSearches[2], 'Software-Heroes', 'software_heroes', RRF_WEIGHTS.software_heroes, onlineBoost * 0.9)
+      ...processOnlineSource(
+        onlineSearches[0],
+        'SAP Help',
+        'sap_help',
+        RRF_WEIGHTS.sap_help,
+        onlineBoost,
+        10,
+        includeSupportContent ? (result) => !isSupportContentResult(result) : undefined
+      ),
+      ...(includeSupportContent
+        ? processOnlineSource(
+            onlineSearches[1],
+            'SAP Help Support Content',
+            'sap_help',
+            SUPPORT_CONTENT_RRF_WEIGHT,
+            onlineBoost * 0.5,
+            5
+          )
+        : []),
+      ...processOnlineSource(onlineSearches[2], 'SAP Community', 'sap_community', RRF_WEIGHTS.sap_community, onlineBoost * 0.5),
+      ...processOnlineSource(onlineSearches[3], 'Software-Heroes', 'software_heroes', RRF_WEIGHTS.software_heroes, onlineBoost * 0.9)
     );
     
     console.log(`🌐 [ONLINE] Total: ${onlineResults.length} online results`);

--- a/test/product-filter-sap-help.test.ts
+++ b/test/product-filter-sap-help.test.ts
@@ -108,4 +108,28 @@ describe("SAP Help `product` scope (online-merge pollution fix)", () => {
     },
     NET_TIMEOUT
   );
+
+  it(
+    "strict SUPPORT_CONTENT scope returns old Support Content without falling back to broad SAP Help",
+    async (ctx) => {
+      let res: SearchResponse;
+      try {
+        res = await searchSapHelp("SAP Transportation Management", "1.0", "SUPPORT_CONTENT", { relax: false });
+      } catch (e: any) {
+        console.warn(`[product-filter] SAP Help threw, skipping: ${e?.message}`);
+        ctx.skip();
+        return;
+      }
+      if (res.error || (res.results?.length ?? 0) === 0) {
+        console.warn(`[product-filter] SAP Help unreachable/empty, skipping (error: ${res.error ?? "none"})`);
+        ctx.skip();
+        return;
+      }
+
+      expect((res.results ?? []).length).toBeGreaterThan(0);
+      expect((res.results ?? []).every((r) => r.metadata?.productId === "SUPPORT_CONTENT")).toBe(true);
+      expect((res.results ?? []).every((r) => r.url?.includes("/docs/SUPPORT_CONTENT/"))).toBe(true);
+    },
+    NET_TIMEOUT
+  );
 });


### PR DESCRIPTION
## Goal

Include SAP Help Support Content as a low-priority enrichment for legacy SAPWiki-style material without exposing it as a separate public search source or letting it dominate regular SAP Help/offline results.

## Changes

- Adds a strict `SUPPORT_CONTENT` SAP Help query path using version `1.0` and no fallback relaxation.
- Keeps Support Content as internal SAP Help enrichment: returned results use `sourceKind: "sap_help"` and `source: "sap-help"`.
- Tags those hits with provenance metadata (`sourceSubkind: "support_content"`, `supportContent: true`, `legacyKnowledge: true`, `productId: "SUPPORT_CONTENT"`).
- Applies a lower internal RRF weight and caps the enrichment to 5 results so it complements rather than overshadows regular sources.
- Removes `sap_support_content` from the public tool docs and sourceKind contract.
- Adds a network test that verifies strict Support Content scoping stays inside `/docs/SUPPORT_CONTENT/`.

## Validation

- `npm run build:tsc`
- `npx vitest run test/search-response-schema.test.ts`
- `npm run test:product-filter`
- Live smoke search for `SAP Transportation Management planning cockpit notes`: Support Content hits returned as `sap_help` with `sourceSubkind: "support_content"` at ranks 19, 21, 23, 27, and 30.