### PR TITLE
fix(streamable-http): keep idle SSE streams alive

### DIFF
--- a/src/lib/sseKeepAlive.ts
+++ b/src/lib/sseKeepAlive.ts
@@ -1,0 +1,42 @@
+import type { ServerResponse } from "node:http";
+
+/**
+ * Heartbeat interval for SSE responses. Has to stay under the shortest idle limit any hop
+ * imposes: undici's 300 s `bodyTimeout` in Node-based MCP clients, and nginx's 60 s
+ * `proxy_read_timeout` in front of the public deployment.
+ */
+const SSE_KEEPALIVE_MS = 30_000;
+
+/**
+ * Writes a periodic SSE comment to `res` for as long as it is an open `text/event-stream`
+ * response, and stops when the response closes.
+ *
+ * Why this is needed: the MCP standalone GET stream carries zero bytes while the client is
+ * idle — the SDK only writes to it for server-initiated notifications, which this server
+ * never sends. Node-based MCP clients read that stream with `fetch`, and undici's default
+ * 300 s `bodyTimeout` aborts a body that goes that long without a chunk, surfacing as
+ * `TypeError: terminated` (cause `BodyTimeoutError`). The client then reconnects, and
+ * concurrent reconnect GETs collide with the SDK's "only one standalone SSE stream per
+ * session" rule and get HTTP 409 — which burns the client's 2-attempt retry budget and
+ * permanently disables the server for that session. See marianfoo/abap-mcp-server#3.
+ *
+ * `:` lines are SSE comments; every SSE parser ignores them (the MCP client SDK explicitly
+ * skips data-less events). The content-type check matters: the same handler also serves
+ * plain `application/json` responses, and a stray comment line would corrupt those.
+ */
+export function startSseKeepAlive(res: ServerResponse, intervalMs = SSE_KEEPALIVE_MS): NodeJS.Timeout {
+  const timer = setInterval(() => {
+    if (
+      res.headersSent &&
+      res.writable &&
+      !res.writableEnded &&
+      String(res.getHeader("content-type") ?? "").includes("text/event-stream")
+    ) {
+      res.write(": keepalive\n\n");
+    }
+  }, intervalMs);
+
+  timer.unref();
+  res.on("close", () => clearInterval(timer));
+  return timer;
+}

--- a/src/streamable-http-server.ts
+++ b/src/streamable-http-server.ts
@@ -13,6 +13,7 @@ import { prefetchFeatureMatrix } from "./lib/softwareHeroes/abapFeatureMatrix.js
 import { prefetchUi5LibDiff } from "./lib/ui5LibDiff/index.js";
 import { loadEmbeddingModel } from "./lib/embeddingSearch.js";
 import { CONFIG } from "./lib/config.js";
+import { startSseKeepAlive } from "./lib/sseKeepAlive.js";
 
 const VERSION = "0.3.51"; // x-release-please-version
 const variant = getVariantConfig();
@@ -277,6 +278,10 @@ async function main() {
         return;
       }
       
+      // Stop idle SSE streams from being killed after 5 min and triggering a 409 reconnect
+      // storm — see the comment on startSseKeepAlive.
+      startSseKeepAlive(res);
+
       // Handle the request with the transport
       await transport.handleRequest(req, res, req.body);
     } catch (error) {

--- a/test/sse-keepalive.test.ts
+++ b/test/sse-keepalive.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, afterEach } from "vitest";
+import express from "express";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { startSseKeepAlive } from "../src/lib/sseKeepAlive.js";
+
+// Regression guard for marianfoo/abap-mcp-server#3: an idle MCP SSE stream used to sit
+// silent until the client's undici `bodyTimeout` (300 s) tore it down, which kicked off the
+// 409 reconnect storm. A short interval is used so the test runs in milliseconds rather than
+// minutes.
+const INTERVAL = 20;
+
+let server: http.Server | undefined;
+
+async function listen(app: express.Express): Promise<string> {
+  server = app.listen(0, "127.0.0.1");
+  await new Promise(resolve => server!.once("listening", resolve));
+  return `http://127.0.0.1:${(server!.address() as AddressInfo).port}`;
+}
+
+afterEach(() => {
+  server?.close();
+  server = undefined;
+});
+
+describe("startSseKeepAlive", () => {
+  it("heartbeats an idle text/event-stream response without ending it", async () => {
+    const app = express();
+    app.get("/sse", (_req, res) => {
+      startSseKeepAlive(res, INTERVAL);
+      res.writeHead(200, { "Content-Type": "text/event-stream", "Cache-Control": "no-cache" });
+      res.flushHeaders();
+      // Deliberately never writes anything else — this is the idle standalone MCP stream.
+    });
+
+    const base = await listen(app);
+    const res = await fetch(`${base}/sse`, { headers: { accept: "text/event-stream" } });
+    const reader = res.body!.getReader();
+    const decoder = new TextDecoder();
+
+    let received = "";
+    while (!received.includes(": keepalive\n\n")) {
+      const { value, done } = await reader.read();
+      expect(done, "stream ended instead of heartbeating").toBe(false);
+      received += decoder.decode(value!);
+    }
+    expect(received.startsWith(": keepalive\n\n")).toBe(true);
+    await reader.cancel();
+  });
+
+  it("leaves a non-SSE response untouched", async () => {
+    const app = express();
+    app.get("/json", (_req, res) => {
+      startSseKeepAlive(res, INTERVAL);
+      // Slower than the heartbeat: if the guard were missing, a comment line would be
+      // written into the JSON body and the parse below would fail.
+      setTimeout(() => res.json({ ok: true }), INTERVAL * 4);
+    });
+
+    const base = await listen(app);
+    const res = await fetch(`${base}/json`);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it("clears the interval once the response is closed", async () => {
+    const app = express();
+    let timer: NodeJS.Timeout | undefined;
+    app.get("/sse", (_req, res) => {
+      timer = startSseKeepAlive(res, INTERVAL);
+      res.writeHead(200, { "Content-Type": "text/event-stream" });
+      res.flushHeaders();
+    });
+
+    const base = await listen(app);
+    const controller = new AbortController();
+    const res = await fetch(`${base}/sse`, {
+      headers: { accept: "text/event-stream" },
+      signal: controller.signal
+    });
+    void res.body!.getReader().read().catch(() => {});
+    controller.abort();
+    await new Promise(resolve => setTimeout(resolve, INTERVAL * 4));
+
+    // `_destroyed` is Node-internal, but it is the only observable difference between a
+    // cleared timer and a live one — `hasRef()` is already false because we unref(). Without
+    // this assertion the test would pass even if the interval leaked, and one leaked 30 s
+    // interval per dropped session adds up on the public server.
+    expect((timer as unknown as { _destroyed: boolean })._destroyed).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes marianfoo/abap-mcp-server#3 — *"Streamable HTTP connection drops after ~5 minutes and reconnect fails with HTTP 409"*, reported against GitHub Copilot for Eclipse.

## Root cause

The 409 is a symptom; the disconnect is the bug.

1. **The standalone GET SSE stream is silent by construction.** The SDK writes to it only for server-initiated notifications, which this server never sends. Priming events don't cover it either — those are POST-only and gated on protocol ≥ `2025-11-25`. After the response headers it carries **zero bytes, forever**.

2. **undici aborts it at exactly 300 s.** Node-based MCP clients (Copilot's language server included) read the stream with `fetch`, and undici's default `bodyTimeout` is 300 000 ms. Probe on Node 22, one silent SSE response read by two clients:

   ```
   [+301.0s] server: response CLOSED (writableEnded=false, aborted=true)
   [+301.0s] clientA(fetch):  THREW TypeError: terminated  cause=BodyTimeoutError
   [+420.0s] clientB(raw http.request): still connected
   ```

   `TypeError: terminated` is byte-for-byte the error in the Eclipse log. Node's `server.requestTimeout` — also 300 s and *not* disabled in our code — is **not** involved: the raw client on the identical response survived past 7 minutes.

3. **The 409 is the client colliding with itself.** `webStandardStreamableHttp.js:209` permits one standalone GET per session. The reporter's log shows two streams dying 500 ms apart, each scheduling its own reconnect — one wins, the other gets 409, and the client SDK's `maxRetries: 2` is exhausted → `Maximum reconnection attempts (2) exceeded`, permanently. The session stays healthy server-side, which is why the server log looks fine while the tools are dead.

There is **no server-side session leak**: SDK 1.26 + `@hono/node-server` do free the stream slot on socket close, and a reconnect after a destroyed stream gets 200. Verified.

## Fix

A 30 s `: keepalive` SSE comment on any `text/event-stream` response. The stream never goes idle, so it is never terminated, so there is no reconnect and no collision. 30 s also clears nginx's 60 s `proxy_read_timeout` in front of the public deployment.

`:` lines are SSE comments — every parser ignores them, and the MCP client SDK explicitly skips data-less events. The content-type guard matters: the same handler also serves plain `application/json`, where a stray comment would corrupt the body.

Deliberately **not** doing: evicting the stale stream when a colliding GET arrives. With two racing reconnects that degenerates into an eviction ping-pong — strictly worse than the 409.

## Verification

**End-to-end, real SDK client + server transports, held past the 5-minute mark:**

```
=== without keep-alive ===              === with keep-alive ===
[+301.0s] SSE stream disconnected:      [+375.0s] errors observed: 0
          TypeError: terminated
[+302.0s] server: GET transport_reused
[+375.0s] errors observed: 2
```

**12 integration checks** against the real transports wired as in `streamable-http-server.ts`, with an aggressive 25 ms heartbeat so keep-alives land mid-response — all pass:

- a 5 KB `tools/call` result arrives intact with heartbeats interleaved through its SSE frames
- `tools/list` parses; no client or transport errors
- the standalone stream actually receives `: keepalive` comments
- a second standalone GET on a live session is still 409 (behaviour unchanged)
- `DELETE /mcp` still terminates the session and clears the transport map
- the stateless one-shot POST path and the 400 JSON path contain no stray comment
- all 11 keep-alive timers cleared after their responses closed

**3 unit tests** in `test/sse-keepalive.test.ts`, each verified to fail when the code it guards is removed.

`tsc --noEmit` clean. `test:url-generation` is unchanged from baseline (9 failed / 345 passed with and without this change — pre-existing UI5 URL-generation failures, unrelated).

## Note, not fixed here

`protocolVersions: ["2025-07-09"]` in `src/streamable-http-server.ts` is not a real MCP protocol revision. Out of scope for this fix, but worth a look — among other things it keeps the SDK from sending priming events with a `retry:` hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
