### PR TITLE
docs: add Werkbank install button

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,5 +357,5 @@ MCP_VARIANT=abap npm run build:fts
 - `docs/UPSTREAM-ONE-WAY-SYNC-IMPLEMENTATION.md`
 - `REMOTE_SETUP.md`
 
-[werkbank-badge]: https://img.shields.io/badge/Add%20to%20Werkbank-6d28d9?style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA0NCA0NCI+PHBhdGggZD0iTTIyIDQgMzggMjAgMjIgNDAgNiAyMHoiIGZpbGw9IiNmZmYiLz48L3N2Zz4=
-[werkbank-install]: https://mcp-sap-docs.marianzeis.de/install/werkbank?name=sap-docs&config=eyJ0eXBlIjoic3RyZWFtYWJsZV9odHRwIiwidXJsIjoiaHR0cHM6Ly9tY3Atc2FwLWRvY3MubWFyaWFuemVpcy5kZS9tY3AiLCJkZXNjcmlwdGlvbiI6IlNBUCBkb2N1bWVudGF0aW9uLCBub3RlcyBhbmQgY29tbXVuaXR5IHNlYXJjaCJ9
+[werkbank-badge]: assets/add-to-werkbank.svg
+[werkbank-install]: werkbank://install-mcp?name=sap-docs&config=eyJ0eXBlIjoic3RyZWFtYWJsZV9odHRwIiwidXJsIjoiaHR0cHM6Ly9tY3Atc2FwLWRvY3MubWFyaWFuemVpcy5kZS9tY3AiLCJkZXNjcmlwdGlvbiI6IlNBUCBkb2N1bWVudGF0aW9uLCBub3RlcyBhbmQgY29tbXVuaXR5IHNlYXJjaCJ9

--- a/README.md
+++ b/README.md
@@ -358,4 +358,4 @@ MCP_VARIANT=abap npm run build:fts
 - `REMOTE_SETUP.md`
 
 [werkbank-badge]: assets/add-to-werkbank.svg
-[werkbank-install]: werkbank://install-mcp?name=sap-docs&config=eyJ0eXBlIjoic3RyZWFtYWJsZV9odHRwIiwidXJsIjoiaHR0cHM6Ly9tY3Atc2FwLWRvY3MubWFyaWFuemVpcy5kZS9tY3AiLCJkZXNjcmlwdGlvbiI6IlNBUCBkb2N1bWVudGF0aW9uLCBub3RlcyBhbmQgY29tbXVuaXR5IHNlYXJjaCJ9
+[werkbank-install]: https://getwerkbank.com/install-mcp?name=sap-docs&config=eyJ0eXBlIjoic3RyZWFtYWJsZV9odHRwIiwidXJsIjoiaHR0cHM6Ly9tY3Atc2FwLWRvY3MubWFyaWFuemVpcy5kZS9tY3AiLCJkZXNjcmlwdGlvbiI6IlNBUCBkb2N1bWVudGF0aW9uLCBub3RlcyBhbmQgY29tbXVuaXR5IHNlYXJjaCJ9

--- a/README.md
+++ b/README.md
@@ -358,4 +358,4 @@ MCP_VARIANT=abap npm run build:fts
 - `REMOTE_SETUP.md`
 
 [werkbank-badge]: https://img.shields.io/badge/Add%20to%20Werkbank-6d28d9?style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA0NCA0NCI+PHBhdGggZD0iTTIyIDQgMzggMjAgMjIgNDAgNiAyMHoiIGZpbGw9IiNmZmYiLz48L3N2Zz4=
-[werkbank-install]: werkbank://install-mcp?name=sap-docs&config=eyJ0eXBlIjoic3RyZWFtYWJsZV9odHRwIiwidXJsIjoiaHR0cHM6Ly9tY3Atc2FwLWRvY3MubWFyaWFuemVpcy5kZS9tY3AiLCJkZXNjcmlwdGlvbiI6IlNBUCBkb2N1bWVudGF0aW9uLCBub3RlcyBhbmQgY29tbXVuaXR5IHNlYXJjaCJ9
+[werkbank-install]: https://mcp-sap-docs.marianzeis.de/install/werkbank?name=sap-docs&config=eyJ0eXBlIjoic3RyZWFtYWJsZV9odHRwIiwidXJsIjoiaHR0cHM6Ly9tY3Atc2FwLWRvY3MubWFyaWFuemVpcy5kZS9tY3AiLCJkZXNjcmlwdGlvbiI6IlNBUCBkb2N1bWVudGF0aW9uLCBub3RlcyBhbmQgY29tbXVuaXR5IHNlYXJjaCJ9

--- a/README.md
+++ b/README.md
@@ -2,6 +2,25 @@
 
 An MCP server that gives AI assistants (Claude, Cursor, ChatGPT, etc.) access to SAP documentation through a unified search and fetch interface. It combines a local full-text + semantic index over git-cloned SAP docs with optional live queries to SAP Help, SAP Community, and Software Heroes — all exposed as MCP tools.
 
+## Install
+
+[![Add to Werkbank][werkbank-badge]][werkbank-install]
+
+Or add it to any MCP client that supports streamable HTTP:
+
+```json
+{
+  "mcpServers": {
+    "sap-docs": {
+      "type": "http",
+      "url": "https://mcp-sap-docs.marianzeis.de/mcp"
+    }
+  }
+}
+```
+
+No API key or login required — the server is public and read-only.
+
 ## Public Hosted Endpoint
 
 > **Ready to use — no setup required**
@@ -337,3 +356,6 @@ MCP_VARIANT=abap npm run build:fts
 - `docs/TESTS.md`
 - `docs/UPSTREAM-ONE-WAY-SYNC-IMPLEMENTATION.md`
 - `REMOTE_SETUP.md`
+
+[werkbank-badge]: https://img.shields.io/badge/Add%20to%20Werkbank-6d28d9?style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA0NCA0NCI+PHBhdGggZD0iTTIyIDQgMzggMjAgMjIgNDAgNiAyMHoiIGZpbGw9IiNmZmYiLz48L3N2Zz4=
+[werkbank-install]: werkbank://install-mcp?name=sap-docs&config=eyJ0eXBlIjoic3RyZWFtYWJsZV9odHRwIiwidXJsIjoiaHR0cHM6Ly9tY3Atc2FwLWRvY3MubWFyaWFuemVpcy5kZS9tY3AiLCJkZXNjcmlwdGlvbiI6IlNBUCBkb2N1bWVudGF0aW9uLCBub3RlcyBhbmQgY29tbXVuaXR5IHNlYXJjaCJ9

--- a/assets/add-to-werkbank.svg
+++ b/assets/add-to-werkbank.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="197" height="44" viewBox="0 0 197 44" role="img" aria-label="Add to Werkbank">
+  <title>Add to Werkbank</title>
+  <rect width="197" height="44" rx="9" fill="#5B3FE8"/>
+  <g transform="translate(18 11)">
+    <path d="M11 0 22 11 11 22 0 11z" fill="#ffffff"/>
+    <path d="M11 0 15.5 11 11 22 6.5 11z" fill="#5B3FE8" opacity=".18"/>
+  </g>
+  <text x="50" y="28" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Inter,system-ui,sans-serif"
+        font-size="15.5" font-weight="600" fill="#ffffff">Add to Werkbank</text>
+</svg>

--- a/src/streamable-http-server.ts
+++ b/src/streamable-http-server.ts
@@ -16,12 +16,6 @@ import { CONFIG } from "./lib/config.js";
 
 const VERSION = "0.3.51"; // x-release-please-version
 const variant = getVariantConfig();
-const WERKBANK_INSTALL_NAME = 'sap-docs';
-const WERKBANK_INSTALL_CONFIG = Buffer.from(JSON.stringify({
-  type: 'streamable_http',
-  url: 'https://mcp-sap-docs.marianzeis.de/mcp',
-  description: 'SAP documentation, notes and community search'
-})).toString('base64url');
 
 
 // Simple in-memory event store for resumability
@@ -123,27 +117,6 @@ async function main() {
     origin: '*', // Allow all origins - adjust as needed for production
     exposedHeaders: ['Mcp-Session-Id']
   }));
-
-  // GitHub strips custom URL schemes from rendered README links. Keep the
-  // user-initiated click on HTTPS, then hand it off to the local Werkbank app.
-  app.get('/install/werkbank', (req: Request, res: Response) => {
-    const name = typeof req.query.name === 'string' ? req.query.name : '';
-    const config = typeof req.query.config === 'string' ? req.query.config : '';
-
-    if (name !== WERKBANK_INSTALL_NAME || config !== WERKBANK_INSTALL_CONFIG) {
-      res.status(400).json({
-        error: 'Invalid Werkbank install link',
-        message: 'The install link parameters do not match the sap-docs configuration.'
-      });
-      return;
-    }
-
-    const installParams = new URLSearchParams({ name, config });
-    const installUrl = `werkbank://install-mcp?${installParams.toString()}`;
-
-    res.set('Cache-Control', 'no-store');
-    res.redirect(302, installUrl);
-  });
 
   // Store transports by session ID
   const transports: { [sessionId: string]: StreamableHTTPServerTransport } = {};

--- a/src/streamable-http-server.ts
+++ b/src/streamable-http-server.ts
@@ -16,6 +16,12 @@ import { CONFIG } from "./lib/config.js";
 
 const VERSION = "0.3.51"; // x-release-please-version
 const variant = getVariantConfig();
+const WERKBANK_INSTALL_NAME = 'sap-docs';
+const WERKBANK_INSTALL_CONFIG = Buffer.from(JSON.stringify({
+  type: 'streamable_http',
+  url: 'https://mcp-sap-docs.marianzeis.de/mcp',
+  description: 'SAP documentation, notes and community search'
+})).toString('base64url');
 
 
 // Simple in-memory event store for resumability
@@ -117,6 +123,27 @@ async function main() {
     origin: '*', // Allow all origins - adjust as needed for production
     exposedHeaders: ['Mcp-Session-Id']
   }));
+
+  // GitHub strips custom URL schemes from rendered README links. Keep the
+  // user-initiated click on HTTPS, then hand it off to the local Werkbank app.
+  app.get('/install/werkbank', (req: Request, res: Response) => {
+    const name = typeof req.query.name === 'string' ? req.query.name : '';
+    const config = typeof req.query.config === 'string' ? req.query.config : '';
+
+    if (name !== WERKBANK_INSTALL_NAME || config !== WERKBANK_INSTALL_CONFIG) {
+      res.status(400).json({
+        error: 'Invalid Werkbank install link',
+        message: 'The install link parameters do not match the sap-docs configuration.'
+      });
+      return;
+    }
+
+    const installParams = new URLSearchParams({ name, config });
+    const installUrl = `werkbank://install-mcp?${installParams.toString()}`;
+
+    res.set('Cache-Control', 'no-store');
+    res.redirect(302, installUrl);
+  });
 
   // Store transports by session ID
   const transports: { [sessionId: string]: StreamableHTTPServerTransport } = {};


### PR DESCRIPTION
## Summary

- add the supplied `assets/add-to-werkbank.svg` badge asset
- add an Install section near the top of the README
- include a manual streamable HTTP configuration fallback
- route the install button through `https://getwerkbank.com/install-mcp` so GitHub preserves the clickable link
- keep the badge and install URL reference definitions at the bottom of the README

## Validation

- `xmllint --noout assets/add-to-werkbank.svg`
- `git diff --check`
- verified GitHub's Markdown renderer retains `getwerkbank.com` as the badge target
- decoded the Base64URL payload and verified it exactly matches the requested transport, public endpoint, and description

## Deployment note

The `getwerkbank.com/install-mcp` handoff is referenced now but will only launch Werkbank after the domain and GitHub Pages handoff page are configured.