### PR TITLE
fix(ci): restore ABAP deployment after upstream sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,28 +298,40 @@ This repository contains direct sync automation:
 
 Flow:
 
-1. Push to `mcp-sap-docs/main`
-2. Workflow clones `abap-mcp-server`
-3. Tracked upstream files are synced (with exclude rules)
-4. ABAP overlay is applied
-5. `.mcp-variant` is forced to `abap`
-6. ABAP package identity is patched
-7. Commit is pushed to `abap-mcp-server/main`
+1. Release Please publishes a release in `mcp-sap-docs` after its release PR is merged
+2. The release workflow explicitly dispatches the ABAP sync workflow
+3. The sync workflow clones `abap-mcp-server`
+4. Tracked upstream files are synced (with exclude rules), then the ABAP overlay is applied
+5. `.mcp-variant` is forced to `abap` and ABAP package identity is patched
+6. A sync commit is pushed to `abap-mcp-server/main`
+7. That push triggers the ABAP deployment workflow
+
+The sync workflow also supports manual runs, including dry runs and a custom target branch.
+Only pushes to the downstream `main` branch trigger automatic deployment.
 
 Required secret in `mcp-sap-docs` repo:
 
-- `ABAP_REPO_SYNC_TOKEN`
-
-Commit message controls:
-
-- `[skip-sync]` skips sync workflow
+- `ABAP_REPO_SYNC_TOKEN`: a dedicated token with access to push code and workflow
+  changes to `abap-mcp-server`. Keep this separate from `GITHUB_TOKEN`, whose
+  pushes do not trigger subsequent workflows.
 
 ## Deployment Model
 
-- `mcp-sap-docs`: upstream implementation + sync trigger
-- `abap-mcp-server`: deployment trigger remains push-to-main in that repository
+- `mcp-sap-docs`: owns release versions and dispatches its deployment and ABAP sync when a release is created
+- `abap-mcp-server`: deploys on pushes to `main`, including upstream sync commits, or via `workflow_dispatch`
 
-This preserves ABAP deployment automation while keeping one shared upstream codebase.
+The downstream repository does not publish GitHub releases. Its deployment must
+therefore listen for sync pushes, not `release: published`. Upstream releases
+control when automatic syncs occur.
+
+The ABAP deployment workflow is maintained in
+`sync/abap.overlay/.github/workflows/deploy-abap-mcp-server.yml`. Change that
+upstream overlay so the fix persists across future syncs.
+
+After merging a deployment fix, publish the next upstream release or manually run
+`sync-to-abap-main.yml` against upstream `main`. Confirm that the downstream deploy
+run succeeds and that `https://mcp-abap.marianzeis.de/health` reports the version in
+the synced ABAP `package.json`; a successful sync alone does not confirm deployment.
 
 ## PM2 Runtime
 

--- a/sync/abap.overlay/.github/workflows/deploy-abap-mcp-server.yml
+++ b/sync/abap.overlay/.github/workflows/deploy-abap-mcp-server.yml
@@ -1,8 +1,9 @@
 name: Deploy MCP stack
 
 on:
-  release:
-    types: [ published ]
+  # Upstream releases arrive as sync pushes; this repository does not publish releases.
+  push:
+    branches: [ main ]
 
   # Allow manual triggering
   workflow_dispatch:


### PR DESCRIPTION
ABAP production remains on 0.3.45 although upstream releases have synced successfully through 0.3.54. PR #41 changed the downstream deployment trigger to `release: published`, but `abap-mcp-server` receives sync pushes and does not publish releases. The last downstream deployment ran on May 21.

Restore deployment on pushes to downstream `main` in the upstream ABAP overlay, retaining manual dispatch. Upstream release automation continues to control automatic syncs. Update the README to explain the release → sync → deployment flow, the dedicated sync token, and where the downstream workflow is maintained.

Validation:

- `actionlint 1.7.12` passed for the release, sync, and ABAP deployment workflows (external ShellCheck/Pyflakes integrations disabled); `bash -n scripts/sync-to-abap.sh` and `git diff --check` passed.
- Ran the actual sync script against a disposable local bare copy of current `abap-mcp-server/main`. Reproduced the missing push trigger before the fix and verified the generated workflow accepts `main`, excludes a custom branch, and retains manual dispatch.
- Verified dry run leaves the target unchanged, real sync preserves ABAP package identity and release version, repeat sync is a no-op, and a custom-branch sync leaves `main` unchanged.
- No production deployment was triggered. GitHub delivery of the downstream push event and the live deployment still need verification after rollout.

After merge, publish the next upstream release or manually dispatch the upstream sync workflow on `main`. Confirm the downstream deployment succeeds and public `/health` matches the synced package version before closing #82.

Related to #82.
